### PR TITLE
feat: do not use default admin, add web extensions help

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,8 +59,6 @@ OC_DOCKER_TAG=
 # Domain of openCloud, where you can find the frontend.
 # Defaults to "cloud.opencloud.test"
 OC_DOMAIN=
-# openCloud admin user password. Defaults to "admin".
-ADMIN_PASSWORD=
 # Demo users should not be created on a production instance,
 # because their passwords are public. Defaults to "false".
 # If demo users is set to "true", the following user accounts are created automatically:
@@ -81,6 +79,21 @@ LOG_LEVEL=
 # Leaving it default stores data in docker internal volumes.
 # OC_CONFIG_DIR=/your/local/opencloud/config
 # OC_DATA_DIR=/your/local/opencloud/data
+# OpenCloud Web can load extensions from a local directory.
+# The default uses the bind mount to the config/opencloud/apps directory.
+# Example: curl -L https://github.com/opencloud-eu/web-extensions/releases/download/unzip-v1.0.2/unzip-1.0.2.zip | tar -xz -C config/opencloud/apps
+# NOTE: you need to restart the openCloud container to load the new extensions.
+# OC_APPS_DIR=/your/local/opencloud/apps
+
+## OpenCloud Admin Password ##
+# The password for the OpenCloud admin user.
+# The admin user password is randomly generated on the first start of OpenCloud.
+# It will be printed to the console. You can access it by running the following command:
+# `docker compose logs opencloud | grep -B 1 -A 4 "generated OpenCloud Config"`
+# The password is stored in the OpenCloud configuration file.
+# It can only be changed via the OpenCloud User Settings UI or by using the OpenCloud CLI.
+# https://docs.opencloud.eu/docs/admin/resources/common-issues#-change-admin-password-set-in-env
+
 
 # S3 Storage configuration - optional
 # OpenCloud supports S3 storage as primary storage.

--- a/README.md
+++ b/README.md
@@ -219,7 +219,6 @@ Key variables:
 | `COMPOSE_FILE`            | Colon-separated list of compose files to use | (commented out)           |
 | `OC_DOMAIN`               | OpenCloud domain                             | cloud.opencloud.test      |
 | `OC_DOCKER_TAG`           | OpenCloud image tag                          | latest                    |
-| `ADMIN_PASSWORD`          | Admin password                               | admin                     |
 | `OC_CONFIG_DIR`           | Config directory path                        | (Docker volume)           |
 | `OC_DATA_DIR`             | Data directory path                          | (Docker volume)           |
 | `INSECURE`                | Skip certificate validation                  | true                      |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
       OC_INSECURE: "${INSECURE:-false}"
       # basic auth (not recommended, but needed for eg. WebDav clients that do not support OpenID Connect)
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-false}"
-      # admin user password
-      IDM_ADMIN_PASSWORD: "${ADMIN_PASSWORD:-admin}" # this overrides the admin password from the configuration file
       # demo users
       IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
       # email server (if configured)


### PR DESCRIPTION
# Description

Do not use a default admin password. It will be autogenerated during the first start.

## Output

```sh
docker compose logs opencloud | grep -B 1 -A 4 "generated OpenCloud Config"
opencloud-1  | =========================================
opencloud-1  |  generated OpenCloud Config
opencloud-1  | =========================================
opencloud-1  |  configpath : /etc/opencloud/opencloud.yaml
opencloud-1  |  user       : admin
opencloud-1  |  password   : ry4sasz0kz+6Q*jNrxb6aow8Q-bhddCW
```