### PR TITLE
doc: Add hint to use docker compose v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ OpenCloud Compose offers a modular approach to deploying OpenCloud with several 
 
 ### Prerequisites
 
-- Docker and Docker Compose installed
+- Docker and Docker Compose v2 installed. 
 - Domain names pointing to your server (for production deployment)
 - Basic understanding of Docker Compose concepts
+
+> [!IMPORTANT]
+> The docker-compose package in Debian 12 "Bookworm" and most likely other distros based on Debian 12 is v1 instead of the required v2. Using this package will lead to a broken docker deployment.
 
 ### Local Development
 


### PR DESCRIPTION
Hi 🙂

I'm following Opencloud since the beginning and recently started trying to get hands on it. I'm not a professional web or server operator at a hoster, therefore not that familiar with docker and the tooling around.
During my ongoing journey I lost quite some time dealing with strange errors, especially with nested interpolations, e.g. used for defining ```NOTIFICATIONS_SMTP_SENDER```. I finally came to the point realizing, that even the latest Debian 12 Bookworm ships with docker compose v1 which doesn't support nested interpolations.

Trying to give something back to you and the community, I create this PR to hopefully prevent other people spending to much time on this pitfall.

Cheers 🙂