### PR TITLE
feat: support rootless docker deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,24 @@ LOG_DRIVER=
 # needed when self signed certificates are used.
 INSECURE=true
 
+## Rootless Docker ##
+# It is possible to use rootless docker for deploying OpenCloud. Uncomment the below configuration options according to your needs.
+# [MANDATORY]
+# You need to provide the path to your docker socket. This defaults to "/var/run/docker.sock" but changes when running rootlees docker.
+# Usually it is something like "/run/user/[UID]/docker.sock" for rootless docker.
+#DOCKER_SOCKET_PATH="/run/rootlessdocker/docker.sock"
+# The user inside the containers defaults to UID 1000 and GID 1000. In a rootless docker environment, this leads to all volumes for config
+# and data being inaccessible. In a rootless docker environement inside the containers everything needs to be run as "root" to match the
+# user running rootless docker outside of the containers. This can be obtained by setting UID und GID to "0".
+#DOCKER_CONTAINER_UID_GID="0:0"
+# [OPTIONAL]
+# In a rootless docker environment there is a high probability for not being able to use ports below 1000. Use the following two parameters
+# to configure OpenCloud to use other ports than default 80 and 443. It is also possible to change the HTTP und HTTPS ports independent of
+# docker rootless.
+# Don't use ports in the range of 8000-9999 and 5232 as those ports are used internally and therefore might create conflicts.
+#OC_PORT_HTTP="4080"
+#OC_PORT_HTTPS="4443"
+
 ## Features ##
 # The following variable is a convenience variable to enable or disable features of this compose project.
 # Example: if you want to use traefik and letsencrypt, you can set the variable to

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ services:
 - **SSL Certificate Errors**: For local development, accept self-signed certificates by visiting each domain directly in your browser.
 - **Port Conflicts**: If you have services already using ports 80/443, use the external proxy configuration.
 - **Permission Issues**: Ensure data and config directories have proper permissions (owned by user/group 1000).
+- **Rootless Docker**: You can use a rootless docker setup, carefully read and configure your ```.env``` according to the rootless docker section included in ```.env.example```.<br/>However, this is not guaranteed to work properly with all components and configuration options. It is only tested with Traefik and without external proxy and IDP.
 
 ### Logs
 

--- a/config/opencloud/csp.yaml
+++ b/config/opencloud/csp.yaml
@@ -19,7 +19,7 @@ directives:
     - 'blob:'
     - 'https://embed.diagrams.net/'
     # In contrary to bash and docker the default is given after the | character
-    - 'https://${COLLABORA_DOMAIN|collabora.opencloud.test}/'
+    - 'https://${COLLABORA_DOMAIN|collabora.opencloud.test}:${COLLABORA_PORT|443}/'
     # This is needed for the external-sites web extension when embedding sites
     - 'https://docs.opencloud.eu'
   img-src:
@@ -28,7 +28,7 @@ directives:
     - 'blob:'
     - 'https://raw.githubusercontent.com/opencloud-eu/awesome-apps/'
     # In contrary to bash and docker the default is given after the | character
-    - 'https://${COLLABORA_DOMAIN|collabora.opencloud.test}/'
+    - 'https://${COLLABORA_DOMAIN|collabora.opencloud.test}:${COLLABORA_PORT|443}/'
   manifest-src:
     - '''self'''
   media-src:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-latest}
     # changelog: https://github.com/opencloud-eu/opencloud/tree/main/changelog
     # release notes: https://docs.opencloud.eu/opencloud_release_notes.html
+    user: ${DOCKER_CONTAINER_UID_GID:-1000:1000}
     networks:
       opencloud-net:
     entrypoint:
@@ -15,7 +16,7 @@ services:
     environment:
       # enable services that are not started automatically
       OC_ADD_RUN_SERVICES: ${START_ADDITIONAL_SERVICES}
-      OC_URL: https://${OC_DOMAIN:-cloud.opencloud.test}
+      OC_URL: https://${OC_DOMAIN:-cloud.opencloud.test}:${OC_PORT_HTTPS:-443}
       OC_LOG_LEVEL: ${LOG_LEVEL:-info}
       OC_LOG_COLOR: "${LOG_PRETTY:-false}"
       OC_LOG_PRETTY: "${LOG_PRETTY:-false}"

--- a/radicale/radicale.yml
+++ b/radicale/radicale.yml
@@ -6,6 +6,7 @@ services:
       - ./config/opencloud/proxy.yaml:/etc/opencloud/proxy.yaml
   radicale:
     image: ${RADICALE_DOCKER_IMAGE:-opencloudeu/radicale}:${RADICALE_DOCKER_TAG:-latest}
+    user: ${DOCKER_CONTAINER_UID_GID:-1000:1000}
     networks:
       opencloud-net:
     logging:

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -25,10 +25,10 @@ services:
       # enable dashboard
       - "--api.dashboard=true"
       # define entrypoints
-      - "--entryPoints.http.address=:80"
+      - "--entryPoints.http.address=:${OC_PORT_HTTP:-80}"
       - "--entryPoints.http.http.redirections.entryPoint.to=https"
       - "--entryPoints.http.http.redirections.entryPoint.scheme=https"
-      - "--entryPoints.https.address=:443"
+      - "--entryPoints.https.address=:${OC_PORT_HTTPS:-443}"
       # change default timeouts for long-running requests
       # this is needed for webdav clients that do not support the TUS protocol
       - "--entryPoints.https.transport.respondingTimeouts.readTimeout=12h"
@@ -42,8 +42,8 @@ services:
       - "--accessLog.format=json"
       - "--accessLog.fields.headers.names.X-Request-Id=keep"
     ports:
-      - "80:80"
-      - "443:443"
+      - "${OC_PORT_HTTP:-80}:${OC_PORT_HTTP:-80}"
+      - "${OC_PORT_HTTPS:-443}:${OC_PORT_HTTPS:-443}"
     volumes:
       - "${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock:ro"
       - "certs:/certs"

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -5,6 +5,7 @@ services:
     environment:
       # this is needed for setting the correct CSP header
       COLLABORA_DOMAIN: ${COLLABORA_DOMAIN:-collabora.opencloud.test}
+      COLLABORA_PORT: ${OC_PORT_HTTPS:-443}
       # expose nats and the reva gateway for the collaboration service
       NATS_NATS_HOST: 0.0.0.0
       GATEWAY_GRPC_ADDR: 0.0.0.0:9142
@@ -14,6 +15,7 @@ services:
 
   collaboration:
     image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-latest}
+    user: ${DOCKER_CONTAINER_UID_GID:-1000:1000}
     networks:
       opencloud-net:
     depends_on:
@@ -29,11 +31,11 @@ services:
       COLLABORATION_HTTP_ADDR: 0.0.0.0:9300
       MICRO_REGISTRY: "nats-js-kv"
       MICRO_REGISTRY_ADDRESS: "opencloud:9233"
-      COLLABORATION_WOPI_SRC: https://${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}
+      COLLABORATION_WOPI_SRC: https://${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}:${OC_PORT_HTTPS:-443}
       COLLABORATION_APP_NAME: "CollaboraOnline"
       COLLABORATION_APP_PRODUCT: "Collabora"
-      COLLABORATION_APP_ADDR: https://${COLLABORA_DOMAIN:-collabora.opencloud.test}
-      COLLABORATION_APP_ICON: https://${COLLABORA_DOMAIN:-collabora.opencloud.test}/favicon.ico
+      COLLABORATION_APP_ADDR: https://${COLLABORA_DOMAIN:-collabora.opencloud.test}:${OC_PORT_HTTPS:-443}
+      COLLABORATION_APP_ICON: https://${COLLABORA_DOMAIN:-collabora.opencloud.test}:${OC_PORT_HTTPS:-443}/favicon.ico
       COLLABORATION_APP_INSECURE: "${INSECURE:-true}"
       COLLABORATION_CS3API_DATAGATEWAY_INSECURE: "${INSECURE:-true}"
       COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
@@ -51,14 +53,14 @@ services:
     networks:
       opencloud-net:
     environment:
-      aliasgroup1: https://${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}:443
+      aliasgroup1: https://${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}:${OC_PORT_HTTPS:-443}
       DONT_GEN_SSL_CERT: "YES"
       extra_params: |
         --o:ssl.enable=${COLLABORA_SSL_ENABLE:-true} \
         --o:ssl.ssl_verification=${COLLABORA_SSL_VERIFICATION:-true} \
         --o:ssl.termination=true \
         --o:welcome.enable=false \
-        --o:net.frame_ancestors=${OC_DOMAIN:-cloud.opencloud.test}
+        --o:net.frame_ancestors=${OC_DOMAIN:-cloud.opencloud.test}:${OC_PORT_HTTPS:-443}
       username: ${COLLABORA_ADMIN_USER:-admin}
       password: ${COLLABORA_ADMIN_PASSWORD:-admin}
     cap_add:


### PR DESCRIPTION
Hi,

I only use rootless docker environments on my dev-machines, NAS and server. Therefore I made some changes to support also rootless docker but without changing the existing defaults for "normal" docker. The ```.env.example``` contains the necessary for configuration options and some background information and reasoning why those options are required.

I must admit, that I'm not at the point to fully understand everything in the existing compose yaml, especially when it comes to using external IDP or proxy. This is not a use case for me currently, so I didn't explore those options for rootless docker.

As a side effect, this pull request adds the possibility to change the HTTP und HTTPS port when using traefik, even when not being in a rootless docker environment.

If there are any questions or further suggestions to improve, please feel free to reach out to me :slightly_smiling_face: 
Anyway, I'm happy to contribute :smiley:  