### PR TITLE
feat: make traefik log level configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,11 @@ TRAEFIK_SERVICES_TLS_CONFIG="tls.certresolver=letsencrypt"
 #
 # The certificates need to copied into ./certs/, the absolute path inside the container is /certs/.
 # You can also use TRAEFIK_CERTS_DIR=/path/on/host to set the path to the certificates directory.
+# Enable the access log for Traefik by setting the following variable to true.
+TRAEFIK_ACCESS_LOG=
+# Configure the log level for Traefik.
+# Possible values are "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" and "PANIC". Default is "ERROR".
+TRAEFIK_LOG_LEVEL=
 
 
 ## OpenCloud Settings ##

--- a/config/traefik/docker-entrypoint-override.sh
+++ b/config/traefik/docker-entrypoint-override.sh
@@ -27,7 +27,7 @@ add_arg "--entryPoints.https.transport.respondingTimeouts.idleTimeout=3m"
 add_arg "--providers.docker.endpoint=unix:///var/run/docker.sock"
 add_arg "--providers.docker.exposedByDefault=false"
 # access log
-add_arg "--accessLog=true"
+add_arg "--accessLog=${TRAEFIK_ACCESS_LOG:-false}"
 add_arg "--accessLog.format=json"
 add_arg "--accessLog.fields.headers.names.X-Request-Id=keep"
 

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -20,6 +20,8 @@ services:
       - "TRAEFIK_SERVICES_TLS_CONFIG=${TRAEFIK_SERVICES_TLS_CONFIG:-tls.certresolver=letsencrypt}"
       - "TRAEFIK_ACME_MAIL=${TRAEFIK_ACME_MAIL:-example@example.org}"
       - "TRAEFIK_ACME_CASERVER=${TRAEFIK_ACME_CASERVER:-https://acme-v02.api.letsencrypt.org/directory}"
+      - "TRAEFIK_LOG_LEVEL=${TRAEFIK_LOG_LEVEL:-ERROR}"
+      - "TRAEFIK_ACCESS_LOG=${TRAEFIK_ACCESS_LOG:-false}"
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
# Description

Log levels in traefik have not been configurable before.

Now you have the following section in the .env.example

```sh
# Enable the access log for Traefik by setting the following variable to true.
TRAEFIK_ACCESS_LOG=
# Configure the log level for Traefik.
# Possible values are "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" and "PANIC". Default is "ERROR".
TRAEFIK_LOG_LEVEL=
```