### PR TITLE
add ENV:LDAP_ADMIN_PASSWORD to keycloak container

### DIFF
--- a/idm/ldap-keycloak.yml
+++ b/idm/ldap-keycloak.yml
@@ -89,6 +89,7 @@ services:
       - "./config/keycloak/opencloud-realm.dist.json:/opt/keycloak/data/import-dist/opencloud-realm.json"
       - "./config/keycloak/themes/opencloud:/opt/keycloak/themes/opencloud"
     environment:
+      LDAP_ADMIN_PASSWORD: ${LDAP_BIND_PASSWORD:-admin}
       OC_DOMAIN: ${OC_DOMAIN:-cloud.opencloud.test}
       KC_HOSTNAME: ${KEYCLOAK_DOMAIN:-keycloak.opencloud.test}
       KC_DB: postgres


### PR DESCRIPTION
If the LDAP_BIND_PASSWORD has been set in .env
the keycloak container couldn't connect to the ldap container because the env var has not been provided to the container and always defaulted back to admin.
See the entrypoint override for the usage.