### PR TITLE
Update traefik image tag

### DIFF
--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -9,7 +9,7 @@ services:
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
       - "traefik.http.routers.opencloud.${TRAEFIK_SERVICES_TLS_CONFIG}"
   traefik:
-    image: traefik:v3.3.1
+    image: traefik:v3
     # release notes: https://github.com/traefik/traefik/releases
     networks:
       opencloud-net:


### PR DESCRIPTION
Hi opencloud team,

in this PR i´ve update the image tag for the used traefik docker image. Before this update, an specific version tag was set "v.3.3.1". This version is 8 month´s old and active support for this release v3.3.x ends on May 5, 2025 see (https://doc.traefik.io/traefik/deprecation/releases/). With v3 as tag, the latest version in 3.x will be used.

thank for your work :).

Greetings,
Christian