### PR TITLE
set default admin password

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ OpenCloud Compose offers a modular approach to deploying OpenCloud with several 
 5. **Access OpenCloud**:
    - URL: https://cloud.opencloud.test
    - Username: `admin`
-   - Password: Set via `INITIAL_ADMIN_PASSWORD` environment variable in your `.env` file
+   - Password: `admin` (by default). Set via `INITIAL_ADMIN_PASSWORD` environment variable in your `.env` file
 
 ### Production Deployment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       # demo users
       IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-false}"
       # admin password
-      IDM_ADMIN_PASSWORD: "${INITIAL_ADMIN_PASSWORD}"
+      IDM_ADMIN_PASSWORD: "${INITIAL_ADMIN_PASSWORD:-admin}"
       # email server (if configured)
       NOTIFICATIONS_SMTP_HOST: "${SMTP_HOST}"
       NOTIFICATIONS_SMTP_PORT: "${SMTP_PORT}"

--- a/idm/ldap-keycloak.yml
+++ b/idm/ldap-keycloak.yml
@@ -38,7 +38,7 @@ services:
       IDP_DOMAIN: ${KEYCLOAK_DOMAIN:-keycloak.opencloud.test}
 
   ldap-server:
-    image: bitnami/openldap:2.6
+    image: bitnamilegacy/openldap:2.6
     networks:
       opencloud-net:
     entrypoint: [ "/bin/sh", "/opt/bitnami/scripts/openldap/docker-entrypoint-override.sh", "/opt/bitnami/scripts/openldap/run.sh" ]


### PR DESCRIPTION
1. I tried to start opencloud `COMPOSE_FILE=docker-compose.yml:traefik/opencloud.yml` following READMI and encountered an issue in step 3 https://github.com/opencloud-eu/opencloud-compose/blob/main/README.md#local-development

`2025-09-04 11:15:15 2025/09/04 09:15:15 Could not create config: config file already exists, use --force-overwrite to overwrite or --diff to show diff`
`2025-09-04 11:15:16 The password of service user admin has not been set properly in your config for idm. Make sure your /etc/opencloud config contains the proper values (e.g. by using 'opencloud init --diff' and applying the patch or setting a value manually in the config/corresponding environment variable).`

It happens when `INITIAL_ADMIN_PASSWORD` is empty. Following READMI we set password later after starting `docker compose up -d`

2. Changed `bitnami/openldap:2.6` to `bitnamilegacy/openldap:2.6` according https://github.com/opencloud-eu/opencloud/pull/1418