### PR TITLE
fix: smtp sender cannot use nested env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       # email server (if configured)
       NOTIFICATIONS_SMTP_HOST: "${SMTP_HOST}"
       NOTIFICATIONS_SMTP_PORT: "${SMTP_PORT}"
-      NOTIFICATIONS_SMTP_SENDER: "${SMTP_SENDER:-OpenCloud notifications <notifications@${OC_DOMAIN:-cloud.opencloud.test}>}"
+      NOTIFICATIONS_SMTP_SENDER: "${SMTP_SENDER:-OpenCloud Notifications <notifications@cloud.opencloud.test>}"
       NOTIFICATIONS_SMTP_USERNAME: "${SMTP_USERNAME}"
       NOTIFICATIONS_SMTP_PASSWORD: "${SMTP_PASSWORD}"
       NOTIFICATIONS_SMTP_INSECURE: "${SMTP_INSECURE}"


### PR DESCRIPTION
# Description

## Fix SMTP_SENDER

The compose file has been using a nested ENV variable substitution.

The Bug has been reported in https://github.com/orgs/opencloud-eu/discussions/1496

This is the fix.

RFC


> RFC 5322 defines email addresses with display names as: Display Name [local-part@domain](mailto:local-part@domain), where angle brackets (< >) are required around the actual email address when a display name is present. [Campaign Refinery](https://campaignrefinery.com/rfc-5322/)[Fastmail](https://www.fastmail.help/hc/en-us/articles/1500000278382-Email-standards)

> Display names containing special characters (like colons, commas) must be enclosed in double quotes, for example: "John: Smith" [john@example.com](mailto:john@example.com). [Troubleshoot RFC 5322 (duplicate header) bounce messages - Google Workspace Admin Help](https://support.google.com/a/answer/13567860?hl=en)

@Tronde FYI