### PR TITLE
fix: fix syntax of certs.yml configuration file example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ TRAEFIK_SERVICES_TLS_CONFIG="tls.certresolver=letsencrypt"
 #       stores:
 #         - default
 #
-# The certificates need to copied into ./certs/, the absolute path inside the container is /certs/.
+# The certificates need to be copied into ./certs/, the absolute path inside the container is /certs/.
 # You can also use TRAEFIK_CERTS_DIR=/path/on/host to set the path to the certificates directory.
 # Enable the access log for Traefik by setting the following variable to true.
 TRAEFIK_ACCESS_LOG=

--- a/.env.example
+++ b/.env.example
@@ -56,8 +56,8 @@ TRAEFIK_SERVICES_TLS_CONFIG="tls.certresolver=letsencrypt"
 #   certificates:
 #     - certFile: /certs/opencloud.test.crt
 #       keyFile: /certs/opencloud.test.key
-#     stores:
-#       - default
+#       stores:
+#         - default
 #
 # The certificates need to copied into ./certs/, the absolute path inside the container is /certs/.
 # You can also use TRAEFIK_CERTS_DIR=/path/on/host to set the path to the certificates directory.


### PR DESCRIPTION
Using the example from the `.env.example` file to configure `traefik` with a local cert store, creates a broken `certs.yml` configuration file.