### PR TITLE
fix: fix passwords, changed via Keycloak, are not hashed in LDAP #102

### DIFF
--- a/config/keycloak/opencloud-realm.dist.json
+++ b/config/keycloak/opencloud-realm.dist.json
@@ -2336,7 +2336,7 @@
             "always"
           ],
           "usePasswordModifyExtendedOp": [
-            "false"
+            "true"
           ],
           "trustEmail": [
             "false"


### PR DESCRIPTION
This PR fixes the issue that user passwords, changed via Keycloal, are not hashed in LDAP.