### PR TITLE
Change image for OpenLDAP in external-idp to bitnamilegacy

### DIFF
--- a/idm/external-idp.yml
+++ b/idm/external-idp.yml
@@ -44,7 +44,7 @@ services:
       # The openCloud users need to be able to edit their account in the externa IdP
       WEB_OPTION_ACCOUNT_EDIT_LINK_HREF: ${IDP_ACCOUNT_URL}
   ldap-server:
-    image: bitnami/openldap:2.6
+    image: bitnamilegacy/openldap:2.6
     networks:
       opencloud-net:
     entrypoint: [ "/bin/sh", "/opt/bitnami/scripts/openldap/docker-entrypoint-override.sh", "/opt/bitnami/scripts/openldap/run.sh" ]


### PR DESCRIPTION
Same as in https://github.com/opencloud-eu/opencloud-compose/commit/487b73f0b36290df5a8ef8c11374a364dd417a03 but for external-idp.yml.

Issue: https://github.com/opencloud-eu/opencloud-compose/issues/106