### PR TITLE
enhance: do not try to create demo users with Keycloak and LDAP enabled

### DIFF
--- a/idm/ldap-keycloak.yml
+++ b/idm/ldap-keycloak.yml
@@ -31,6 +31,7 @@ services:
       WEB_OPTION_ACCOUNT_EDIT_LINK_HREF: "https://${KEYCLOAK_DOMAIN:-keycloak.opencloud.test}/realms/openCloud/account"
       # admin and demo accounts must be created in Keycloak
       OC_ADMIN_USER_ID: ""
+      IDM_CREATE_DEMO_USERS: "false" 
       SETTINGS_SETUP_DEFAULT_ASSIGNMENTS: "false"
       GRAPH_ASSIGN_DEFAULT_USER_ROLE: "false"
       GRAPH_USERNAME_MATCH: "none"


### PR DESCRIPTION
If `idm/ldap-keycloak.yml` is used to deploy Keycload and LDAP service, it doesn't start the `opencloud` service if the `.env` file also contains `DEMO_USERS=true`.

To avoid this conflicting situation, `idm/ldap-keycloak.yml` disables creating demo users by explicitly setting `IDM_CREATE_DEMO_USERS: "false"`.
 