### PR TITLE
enhane: do not expose ldap service

### DIFF
--- a/idm/external-idp.yml
+++ b/idm/external-idp.yml
@@ -57,9 +57,6 @@ services:
       LDAP_TLS_KEY_FILE: /opt/bitnami/openldap/share/openldap.key
       LDAP_ROOT: "dc=opencloud,dc=eu"
       LDAP_ADMIN_PASSWORD: ${LDAP_BIND_PASSWORD:-admin}
-    ports:
-      - "127.0.0.1:389:1389"
-      - "127.0.0.1:636:1636"
     volumes:
       # Only use the base ldif file to create the base structure
       - ./config/ldap/ldif/10_base.ldif:/ldifs/10_base.ldif

--- a/idm/ldap-keycloak.yml
+++ b/idm/ldap-keycloak.yml
@@ -51,9 +51,6 @@ services:
       LDAP_TLS_KEY_FILE: /opt/bitnami/openldap/share/openldap.key
       LDAP_ROOT: "dc=opencloud,dc=eu"
       LDAP_ADMIN_PASSWORD: ${LDAP_BIND_PASSWORD:-admin}
-    ports:
-      - "127.0.0.1:389:1389"
-      - "127.0.0.1:636:1636"
     volumes:
       - ./config/ldap/ldif/10_base.ldif:/ldifs/10_base.ldif
       - ./config/ldap/ldif/20_admin.ldif:/ldifs/20_admin.ldif


### PR DESCRIPTION
This PR removes exposing the LDAP service to the docker host. This is not needed as all services from the opencloud stack run within the same docker network `opencloud-net`.