### PR TITLE
fix typo in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,7 +216,7 @@ COLLABORA_SSL_VERIFICATION=false
 # Defaults to "partial"
 #ANTIVIRUS_MAX_SCAN_SIZE_MODE=
 # Image version of the ClamAV container.
-# Defaults to "latest"y
+# Defaults to "latest"
 CLAMAV_DOCKER_TAG=
 
 


### PR DESCRIPTION
a wild character found its way into a comment.