### PR TITLE
Fix: Remove confusing comment - notifications is not mandatory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,8 @@ DECOMPOSEDS3_BUCKET=
 
 
 # Define SMTP settings if you would like to send OpenCloud email notifications.
+# To actually send notifications, you also need to enable the 'notifications' service
+# by adding it to the START_ADDITIONAL_SERVICES variable below.
 #
 # NOTE: when configuring Inbucket, these settings have no effect, see inbucket.yml for details.
 # SMTP host to connect to.
@@ -157,11 +159,11 @@ SMTP_TRANSPORT_ENCRYPTION=
 # Allow insecure connections to the SMTP server. Defaults to false.
 SMTP_INSECURE=
 
-# Addititional services to be started on opencloud startup
+# Additional services to be started on opencloud startup
 # The following list of services is not started automatically and must be
 # manually defined for startup:
 # IMPORTANT: Add any services to the startup list comma separated like "notifications,antivirus" etc.
-START_ADDITIONAL_SERVICES="notifications"
+START_ADDITIONAL_SERVICES=""
 
 
 ## Default Enabled Services ##


### PR DESCRIPTION
[Documentation](https://docs.opencloud.eu/docs/admin/configuration/mail-notifications#add-or-modify-these-environment-variables) as well as our [observation](https://codeberg.org/Tronde/opencloud/pulls/24#issuecomment-7720499) shows that the notifications service is not mandatory to start OpenCloud.

This PR removes the obsolete line from `.env.example` and solves #118.

- Fix #118 