### PR TITLE
Allow Android logins with OC docker compose stack using Keycloak in shared directory mode

### DIFF
--- a/config/keycloak/opencloud-realm.dist.json
+++ b/config/keycloak/opencloud-realm.dist.json
@@ -676,6 +676,7 @@
         "profile",
         "roles",
         "groups",
+        "OpenCloudUnique_ID",
         "basic",
         "email"
       ],


### PR DESCRIPTION
This PR fixes #122 by adding the missing `OpenCloudUnique_ID` ClientScope to the `OpenCloudAndroid` client in Keycloak.
