### PR TITLE
Make external IDP LDAP server start automatically

### DIFF
--- a/idm/external-idp.yml
+++ b/idm/external-idp.yml
@@ -65,6 +65,7 @@ services:
       - ./config/ldap/docker-entrypoint-override.sh:/opt/bitnami/scripts/openldap/docker-entrypoint-override.sh
       - ${LDAP_CERTS_DIR:-ldap-certs}:/opt/bitnami/openldap/share
       - ${LDAP_DATA_DIR:-ldap-data}:/bitnami/openldap
+    restart: always
 
 volumes:
   ldap-certs:


### PR DESCRIPTION
Hi,

when restarting my server running OpenCloud, I noticed logins aren't possible via my OIDC provider.
I think it might be because the LDAP server is not running:

```
opencloud-1    | 2025-10-25T20:10:46Z ERR could not get ldap Connection error="LDAP Result Code 200 \"Network Error\": dial tcp: lookup ldap-server on 127.0.0.11:53: no such host" line=github.com/opencloud-eu/reva/v2@v2.38.0/pkg/utils/ldap/reconnect.go:220 service=graph
opencloud-1    | 2025-10-25T20:10:46Z ERR failed to add user error="LDAP Result Code 200 \"Network Error\": dial tcp: lookup ldap-server on 127.0.0.11:53: no such host" line=github.com/opencloud-eu/opencloud/services/graph/pkg/identity/ldap.go:204 request-id=e8c6430d8e8f/HapNzY0xnT-000613 service=graph
```

This commit adds a `restart: always` - same as in https://github.com/opencloud-eu/opencloud-compose/blob/main/idm/ldap-keycloak.yml.