### PR TITLE
feat: add home mode option to Collabora

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -204,6 +204,11 @@ COLLABORA_SSL_ENABLE=false
 # If you're on an internet-facing server, enable SSL verification for Collabora Online.
 # Please comment out the following line:
 COLLABORA_SSL_VERIFICATION=false
+# Enable home mode in Collabore Online.
+# Home users can enable this setting, which in turn disables welcome screen and user feedback popups, 
+# but also limits concurrent open connections to 20 and concurrent open documents to 10.
+# Default is false if not specified.
+COLLABORA_HOME_MODE=
 
 
 ### Virusscanner Settings ###

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -59,7 +59,8 @@ services:
         --o:ssl.termination=true \
         --o:welcome.enable=false \
         --o:net.frame_ancestors=${OC_DOMAIN:-cloud.opencloud.test} \
-        --o:net.lok_allow.host[14]=${OC_DOMAIN-cloud.opencloud.test}
+        --o:net.lok_allow.host[14]=${OC_DOMAIN-cloud.opencloud.test} \
+        --o:home_mode.enable=${COLLABORA_HOME_MODE:-false}
       username: ${COLLABORA_ADMIN_USER:-admin}
       password: ${COLLABORA_ADMIN_PASSWORD:-admin}
     cap_add:


### PR DESCRIPTION
This pull request adds the option to enable Collabora home mode which is a simple way for home users to get rid of the welcome screen and feedback popups. 

This is the official description of the feature:

"Home users can enable this setting, which in turn disables welcome screen and user feedback popups, but also limits concurrent open connections to 20 and concurrent open documents to 10. The default means that number of concurrent open connections and concurrent open documents are unlimited, but welcome screen and user feedback cannot be switched off."

[Source: Collabora Github](https://github.com/CollaboraOnline/online/blob/8c60a51b15cc68d5585dd948411c10ab8ffad680/configure.ac#L989)