### PR TITLE
fix: fix app addr for secure view

### DIFF
--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -9,7 +9,7 @@ services:
       NATS_NATS_HOST: 0.0.0.0
       GATEWAY_GRPC_ADDR: 0.0.0.0:9142
       # make collabora the secure view app
-      FRONTEND_APP_HANDLER_SECURE_VIEW_APP_ADDR: eu.opencloud.api.collaboration.CollaboraOnline
+      FRONTEND_APP_HANDLER_SECURE_VIEW_APP_ADDR: eu.opencloud.api.collaboration
       GRAPH_AVAILABLE_ROLES: "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5,a8d5fe5e-96e3-418d-825b-534dbdf22b99,fb6c3e19-e378-47e5-b277-9732f9de6e21,58c63c02-1d89-4572-916a-870abc5a1b7d,2d00ce52-1fc2-4dbc-8b95-a73b73395f5a,1c996275-f1c9-4e71-abdf-a42f6495e960,312c0871-5ef7-4b3a-85b6-0e4074c64049,aa97fe03-7980-45ac-9e50-b325749fd7e6"
 
   collaboration:


### PR DESCRIPTION
# Background

The collaboration app name has been changed in https://github.com/opencloud-eu/opencloud/pull/1569 which has been released with opencloud 3.6.0.

This will break all instances before version 3.6.0.