### PR TITLE
fix: avoid collaboration anonymous volume

### DIFF
--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -39,6 +39,7 @@ services:
       COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
       OC_URL: https://${OC_DOMAIN:-cloud.opencloud.test}
     volumes:
+      - collaboration-data:/var/lib/opencloud
       # configure the .env file to use own paths instead of docker internal volumes
       - ${OC_CONFIG_DIR:-opencloud-config}:/etc/opencloud
     logging:
@@ -75,3 +76,6 @@ services:
       interval: 15s
       timeout: 10s
       retries: 5
+
+volumes:
+  collaboration-data:


### PR DESCRIPTION
This is more of a cosmetic fix. The collaboration container currently creates an anonymous volume, which is generally not considered good practice. I would avoid mounting the OpenCloud data container to the collaboration containers if it is not necessary, which doesn't seem to be the case. A simple solution is to just give the volume a name. If it is not necessary at all, you could think about changing the Docker image.