### PR TITLE
feat: improve security - configure container uid and gid

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,10 @@ TRAEFIK_ACCESS_LOG=
 # Configure the log level for Traefik.
 # Possible values are "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" and "PANIC". Default is "ERROR".
 TRAEFIK_LOG_LEVEL=
+# The default for traefik is to run in privileged mode.
+# If you want to run traefik non-privileged, use the following variable and the format [UID]:[GID] to set user and group of your choice.
+# Ensure that the user has access to docker.sock and traefik volumes defined in traefik/opencloud.yml
+#TRAEFIK_CONTAINER_UID_GID="1000:1000"
 
 
 ## OpenCloud Settings ##
@@ -77,6 +81,11 @@ OC_DOCKER_IMAGE=opencloudeu/opencloud-rolling
 # The openCloud container version.
 # Defaults to "latest" and points to the latest stable tag.
 OC_DOCKER_TAG=
+# The default id used in opencloud containers is 1000 for user and group.
+# If you want to change the default, use the following variable and the format [UID]:[GID].
+# The change affects all containers with access to data volumes.
+# Ensure that the user has access to all volumes defined in docker-compose.yml
+#OC_CONTAINER_UID_GID="1000:1000"
 # Domain of openCloud, where you can find the frontend.
 # Defaults to "cloud.opencloud.test"
 OC_DOMAIN=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-latest}
     # changelog: https://github.com/opencloud-eu/opencloud/tree/main/changelog
     # release notes: https://docs.opencloud.eu/opencloud_release_notes.html
+    user: ${OC_CONTAINER_UID_GID:-1000:1000}
     networks:
       opencloud-net:
     entrypoint:

--- a/radicale/radicale.yml
+++ b/radicale/radicale.yml
@@ -6,6 +6,7 @@ services:
       - ./config/opencloud/proxy.yaml:/etc/opencloud/proxy.yaml
   radicale:
     image: ${RADICALE_DOCKER_IMAGE:-opencloudeu/radicale}:${RADICALE_DOCKER_TAG:-latest}
+    user: ${OC_CONTAINER_UID_GID:-1000:1000}
     networks:
       opencloud-net:
     logging:

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -11,6 +11,7 @@ services:
   traefik:
     image: traefik:v3
     # release notes: https://github.com/traefik/traefik/releases
+    user: ${TRAEFIK_CONTAINER_UID_GID:-0:0}
     networks:
       opencloud-net:
         aliases:

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -14,6 +14,7 @@ services:
 
   collaboration:
     image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-latest}
+    user: ${OC_CONTAINER_UID_GID:-1000:1000}
     networks:
       opencloud-net:
     depends_on:


### PR DESCRIPTION
Hi!

I had difficulties to achieve strict data access separation on a multi purpose server.

This is caused by not being able to change UID and GID of the users used in the containers. Using 1000:1000 as the default is quite common for a lot of containers on e.g. docker hub. On the host, I need to provide access for user 1000 to directories that are mounted into containers as volumes. From a security perspective, I don't want different containers belonging to completely separated apps or services in principle having access to data or config directories of each other but I'm forced to do so if I'm not able to change the users used in the containers. This is independent of using docker daemon default configuration and still stays the same when utilizing user namespace because the same UID in containers gets translated to the same (transformed) UID in the host in both scenarios which prevents being able to define fine granular access rights and access separation for different containers and applications.

Ideally, I want to have a strict separation of access to application data for each application. For Opencloud it would even be better to have separate access rights for Opencloud and Traefik container because Opencloud container needs access to data but not e.g. the private key from the domain certificate or docker.sock whereas Traefik only needs access to docker.sock, the certificate and some configuration but not the data stored by Opencloud.

In addition, Traefik runs in privileged mode, so using root inside the container which is not best practice from a security perspective. Currently I don't have a chance to configure Traefik to run in non-privileged mode and therfore I'm not able to follow best practice and security recommendations.

This PR introduces two variables `OC_CONTAINER_UID_GID` and `TRAEFIK_CONTAINER_UID_GID`. They can be used to alter the UID and GID for Opencloud and related containers on one hand and Traefik on the other hand. Those two variables offer freedom of choice to implement high security standards by separating data access, running Traefik in non-privileged mode or use Opencloud the same as before if security doesn't concern me a lot.
If those variables are not used, the defaults correspond to the UID and GID used up to now silently.

I would very much appreciate having the option to increase the security of my deployment. This PR is one way to do it, there might also be other ways of implementing it. If you feel this is not the way to do it, please feel free to let me know and deny this PR and propose a different way but as said, in general it would be very beneficial to offer increased security options.

Any questions and other thoughts are very welcome from my side as well 🙂

Cheers