### PR TITLE
fix cert.yml-example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,7 +178,7 @@ START_ADDITIONAL_SERVICES=""
 # search/tika.yml or by using the following command:
 # docker compose -f docker-compose.yml -f search/tika.yml up -d
 # Set the desired docker image tag or digest.
-# Defaults to "apache/tika:slim"
+# Defaults to "apache/tika:latest"
 # The slim variant is recommended for most use cases as it provides core text extraction
 # functionality with a smaller image size and faster startup time.
 # Only use the full variant (apache/tika:latest-full) if you need specialized features


### PR DESCRIPTION
while testing https://github.com/opencloud-eu/qa/blob/main/.github/ISSUE_TEMPLATE/docker-compose_test_plan_template.md#test-92-custom-certificate-configuration-development

i fond that if create certs.yml like this:

```
cat ./config/traefik/dynamic/certs.yml
tls:
  certificates:
    - certFile: /certs/opencloud.test.crt
      keyFile: /certs/opencloud.test.key
  stores:
    default
```

I get error

```
docker-compose logs traefik | grep -A 5 "Configuring Traefik"
traefik-1  | Configuring Traefik with local certificates...
traefik-1  | Starting Traefik with command:
traefik-1  | traefik --log.level=ERROR --api.dashboard=true --entryPoints.http.address=:80 --entryPoints.http.http.redirections.entryPoint.to=https --entryPoints.http.http.redirections.entryPoint.scheme=https --entryPoints.https.address=:443 --entryPoints.https.transport.respondingTimeouts.readTimeout=12h --entryPoints.https.transport.respondingTimeouts.writeTimeout=12h --entryPoints.https.transport.respondingTimeouts.idleTimeout=3m --providers.docker.endpoint=unix:///var/run/docker.sock --providers.docker.exposedByDefault=false --accessLog=false --accessLog.format=json --accessLog.fields.headers.names.X-Request-Id=keep --providers.file.directory=/etc/traefik/dynamic --providers.file.watch=true
traefik-1  | 2025-11-19T14:23:18Z ERR Error while building configuration (for the first time) error="/etc/traefik/dynamic/certs.yml: stores cannot be a standalone element (type map[string]tls.Store)" providerName=file
```


fixed it