### PR TITLE
fix: bind ports on localhost for external proxy

### DIFF
--- a/external-proxy/collabora.yml
+++ b/external-proxy/collabora.yml
@@ -2,9 +2,9 @@
 services:
   collaboration:
     ports:
-      # expose the wopi server
-      - "9300:9300"
+      # expose the wopi server on localhost
+      - "127.0.0.1:9300:9300"
   collabora:
     ports:
-      # expose the collabora server
-      - "9980:9980"
+      # expose the collabora server on localhost
+      - "127.0.0.1:9980:9980"

--- a/external-proxy/keycloak.yml
+++ b/external-proxy/keycloak.yml
@@ -2,5 +2,6 @@
 services:
   keycloak:
     ports:
-      - "9000:9000"
-      - "8080:8080"
+      # expose the keycloak server on localhost
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:8080:8080"

--- a/external-proxy/opencloud.yml
+++ b/external-proxy/opencloud.yml
@@ -5,5 +5,5 @@ services:
         # bind to all interfaces
         PROXY_HTTP_ADDR: "0.0.0.0:9200"
       ports:
-        # expose the opencloud server
-        - "9200:9200"
+        # expose the opencloud server on localhost
+        - "127.0.0.1:9200:9200"


### PR DESCRIPTION
# Description

Bind the ports for the external proxy on localhost, because we assume a local reverse proxy.

This mitigates the problem mentioned in https://medium.com/@akhshyganesh/docker-vs-your-firewall-the-silent-port-sneak-6e4bad366a5e

@zerox80