### PR TITLE
enhance: pin Docker image versions to specific tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,7 +83,7 @@ TRAEFIK_LOG_LEVEL=
 # For production releases: "opencloudeu/opencloud"
 # For rolling releases:    "opencloudeu/opencloud-rolling"
 # Defaults to production if not set otherwise
-OC_DOCKER_IMAGE=opencloudeu/opencloud-rolling
+OC_DOCKER_IMAGE=opencloudeu/opencloud
 # The openCloud container version.
 # Defaults to "latest" and points to the latest stable tag.
 OC_DOCKER_TAG=

--- a/idm/ldap-keycloak.yml
+++ b/idm/ldap-keycloak.yml
@@ -64,7 +64,7 @@ services:
     restart: always
 
   postgres:
-    image: postgres:17-alpine
+    image: postgres:17.7-alpine
     networks:
       opencloud-net:
     volumes:

--- a/search/tika.yml
+++ b/search/tika.yml
@@ -1,7 +1,7 @@
 ---
 services:
   tika:
-    image: ${TIKA_IMAGE:-apache/tika:latest}
+    image: ${TIKA_IMAGE:-apache/tika:3.2.3.0}
     # Using the base variant for smaller image size and faster startup
     # The base variant includes core functionality for text extraction
     # Full variant is only needed for specialized OCR/image processing

--- a/testing/external-keycloak.yml
+++ b/testing/external-keycloak.yml
@@ -1,7 +1,7 @@
 ---
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:17.7-alpine
     networks:
       opencloud-net:
     volumes:

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -9,7 +9,7 @@ services:
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
       - "traefik.http.routers.opencloud.${TRAEFIK_SERVICES_TLS_CONFIG}"
   traefik:
-    image: traefik:v3
+    image: traefik:v3.6.2
     # release notes: https://github.com/traefik/traefik/releases
     user: ${TRAEFIK_CONTAINER_UID_GID:-0:0}
     networks:


### PR DESCRIPTION
This PR pins the Docker image version to specific tags to keep reproducibility and stability for the stable-4.0 branch 