### PR TITLE
fix: slow kit jail error server audit in collabora

### DIFF
--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -65,7 +65,6 @@ services:
         --o:home_mode.enable=${COLLABORA_HOME_MODE:-false}
       username: ${COLLABORA_ADMIN_USER:-admin}
       password: ${COLLABORA_ADMIN_PASSWORD:-admin}
-    privileged: true
     cap_add:
       - SYS_ADMIN
       - MKNOD


### PR DESCRIPTION
<img width="1121" height="674" alt="image" src="https://github.com/user-attachments/assets/18974315-381b-484c-889e-06dbd00307fa" />

Collabora is announcing an error in the server audit, I found a solution described here, which seems to work: 

https://forum.collaboraonline.com/t/error-logged-after-first-install/3845/2
