### PR TITLE
Change environment variable OC_CONFIG_DIR due to overlap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,7 +124,7 @@ LOG_LEVEL=
 # This matches the default user inside the container and avoids permission issues when accessing files.
 # Note that especially the data directory can grow big.
 # Leaving it default stores data in docker internal volumes.
-# OC_CONFIG_DIR=/your/local/opencloud/config
+# OC_CONF_DIR=/your/local/opencloud/config
 # OC_DATA_DIR=/your/local/opencloud/data
 # OpenCloud Web can load extensions from a local directory.
 # The default uses the bind mount to the config/opencloud/apps directory.

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Key variables:
 | `OC_DOMAIN`                   | OpenCloud domain                                      | cloud.opencloud.test         |
 | `INITIAL_ADMIN_PASSWORD `     | OpenCloud password for the admin user                 | (no value)                   |
 | `OC_DOCKER_TAG`               | OpenCloud image tag                                   | latest                       |
-| `OC_CONFIG_DIR`               | Config directory path                                 | (Docker volume)              |
+| `OC_CONF_DIR`               | Config directory path                                 | (Docker volume)              |
 | `OC_DATA_DIR`                 | Data directory path                                   | (Docker volume)              |
 | `INSECURE`                    | Skip certificate validation                           | true                         |
 | `COLLABORA_DOMAIN`            | Collabora domain                                      | collabora.opencloud.test     |
@@ -384,7 +384,7 @@ For more details, see the [OpenCloud documentation](https://docs.opencloud.eu/do
 For production, configure persistent storage:
 
 ```
-OC_CONFIG_DIR=/path/to/opencloud/config
+OC_CONF_DIR=/path/to/opencloud/config
 OC_DATA_DIR=/path/to/opencloud/data
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - ./config/opencloud/csp.yaml:/etc/opencloud/csp.yaml
       - ./config/opencloud/banned-password-list.txt:/etc/opencloud/banned-password-list.txt
       # configure the .env file to use own paths instead of docker internal volumes
-      - ${OC_CONFIG_DIR:-opencloud-config}:/etc/opencloud
+      - ${OC_CONF_DIR:-opencloud-config}:/etc/opencloud
       - ${OC_DATA_DIR:-opencloud-data}:/var/lib/opencloud
       - ${OC_APPS_DIR:-./config/opencloud/apps}:/var/lib/opencloud/web/assets/apps
     logging:

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -42,7 +42,7 @@ services:
       OC_URL: https://${OC_DOMAIN:-cloud.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
     volumes:
       # configure the .env file to use own paths instead of docker internal volumes
-      - ${OC_CONFIG_DIR:-opencloud-config}:/etc/opencloud
+      - ${OC_CONF_DIR:-opencloud-config}:/etc/opencloud
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always


### PR DESCRIPTION
Changed environment variable name from OC_CONFIG_DIR to OC_CONF_DIR due to dual use of the same variable name causing issues in edge cases (per #1279 @ https://github.com/opencloud-eu/opencloud/issues/1279)
PR to docs as well @ https://github.com/opencloud-eu/docs/pull/547