### PR TITLE
Update inline docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,8 +127,8 @@ LOG_LEVEL=
 # This matches the default user inside the container and avoids permission issues when accessing files.
 # Note that especially the data directory can grow big.
 # Leaving it default stores data in docker internal volumes.
-# OC_CONFIG_DIR=/your/local/opencloud/config
-# OC_DATA_DIR=/your/local/opencloud/data
+OC_CONFIG_DIR=
+OC_DATA_DIR=
 # OpenCloud Web can load extensions from a local directory.
 # The default uses the bind mount to the config/opencloud/apps directory.
 # Example: curl -L https://github.com/opencloud-eu/web-extensions/releases/download/unzip-v1.0.2/unzip-1.0.2.zip | tar -xz -C config/opencloud/apps
@@ -136,8 +136,9 @@ LOG_LEVEL=
 #OC_APPS_DIR=/your/local/opencloud/apps
 
 # Define the ldap-server storage location. Set the paths for config and data to a local path.
-# LDAP_CERTS_DIR=
-# LDAP_DATA_DIR=
+# Leaving it default stores data in docker internal volumes.
+LDAP_CERTS_DIR=
+LDAP_DATA_DIR=
 
 # S3 Storage configuration - optional
 # OpenCloud supports S3 storage as primary storage.


### PR DESCRIPTION
i have updated some of the inline documentation.

- added "COMPOSE_FILE=" example for running with an external idp
- moved "TRAEFIK_CERTS_DIR=./certs" from textflow into its own line for external cert usage
- removed leading space from some commented vars, to be in one column with all other vars
- uncommented the following env-vars:
  - OC_CONFIG_DIR, OC_DATA_DIR
  - LDAP_CERTS_DIR, LDAP_DATA_DIR
  to make it more obvious these are important, but left them empty to fallback to default internal volumes