### PR TITLE
fix: traefik rejects supported file characters

### DIFF
--- a/config/traefik/docker-entrypoint-override.sh
+++ b/config/traefik/docker-entrypoint-override.sh
@@ -23,10 +23,14 @@ add_arg "--entryPoints.https.address=:${TRAEFIK_PORT_HTTPS:-443}"
 add_arg "--entryPoints.https.transport.respondingTimeouts.readTimeout=12h"
 add_arg "--entryPoints.https.transport.respondingTimeouts.writeTimeout=12h"
 add_arg "--entryPoints.https.transport.respondingTimeouts.idleTimeout=3m"
-# allow encoded characters required for WOPI/Collabora
+# allow encoded characters
+# required for WOPI/Collabora
 add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedSlash=true"
 add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedQuestionMark=true"
 add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedPercent=true"
+# required for file operations with supported encoded characters
+add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedSemicolon=true"
+add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedHash=true"
 # docker provider (get configuration from container labels)
 add_arg "--providers.docker.endpoint=unix:///var/run/docker.sock"
 add_arg "--providers.docker.exposedByDefault=false"


### PR DESCRIPTION
fixes https://github.com/opencloud-eu/opencloud/issues/2014 as reported by @nicokaiser.

follow up to #173 #174

## testing

create `foo#bar;.txt` in the web UI with no errors