### PR TITLE
fix: example command to load apps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,7 +128,7 @@ LOG_LEVEL=
 # OC_DATA_DIR=/your/local/opencloud/data
 # OpenCloud Web can load extensions from a local directory.
 # The default uses the bind mount to the config/opencloud/apps directory.
-# Example: curl -L https://github.com/opencloud-eu/web-extensions/releases/download/unzip-v1.0.2/unzip-1.0.2.zip | tar -xz -C config/opencloud/apps
+# Example: curl -L https://github.com/opencloud-eu/web-extensions/releases/download/unzip-v1.0.2/unzip-1.0.2.zip -o config/opencloud/apps/unzip-1.0.2.zip && unzip config/opencloud/apps/unzip-1.0.2.zip -d config/opencloud/apps && rm config/opencloud/apps/unzip-1.0.2.zip 
 # NOTE: you need to restart the openCloud container to load the new extensions.
 # OC_APPS_DIR=/your/local/opencloud/apps
 


### PR DESCRIPTION
my tar `GNU tar 1.34` and the tar inside the opencloud container `busybox 1.37.0` seem not to be able to unpack zip files.
So we have to use unzip