### PR TITLE
make PROXY_ROLE_ASSIGNMENT_DRIVER configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -323,6 +323,14 @@ LDAP_BIND_PASSWORD=
 
 ## Autoprovisioning Mode ##
 # Use together with idm/external-idp.yml
+# Role assignment driver for the proxy. Defaults to "oidc".
+# Possible values: "oidc", "default"
+# When set to "oidc", roles are assigned based on OIDC claims.
+# When set to "default", all users get the 'user' role assigned.
+PROXY_ROLE_ASSIGNMENT_DRIVER=
+# Assign the default 'user' role to new users. Defaults to "false".
+# Set to "true" when using PROXY_ROLE_ASSIGNMENT_DRIVER=default
+GRAPH_ASSIGN_DEFAULT_USER_ROLE=
 # If you want to use a keycloak for local testing, you can use testing/external-keycloak.yml and testing/ldap-manager.yml
 # Domain of your Identity Provider.
 IDP_DOMAIN=

--- a/idm/external-idp.yml
+++ b/idm/external-idp.yml
@@ -25,7 +25,7 @@ services:
       WEBFINGER_IOS_OIDC_CLIENT_SCOPES: ${WEBFINGER_IOS_OIDC_CLIENT_SCOPES}
       WEBFINGER_DESKTOP_OIDC_CLIENT_ID: ${WEBFINGER_DESKTOP_OIDC_CLIENT_ID}
       WEBFINGER_DESKTOP_OIDC_CLIENT_SCOPES: ${WEBFINGER_DESKTOP_OIDC_CLIENT_SCOPES}
-      PROXY_ROLE_ASSIGNMENT_DRIVER: "oidc"
+      PROXY_ROLE_ASSIGNMENT_DRIVER: ${PROXY_ROLE_ASSIGNMENT_DRIVER:-oidc}
       OC_OIDC_ISSUER: ${IDP_ISSUER_URL:-https://keycloak.opencloud.test/realms/openCloud}
       # This specifies to start all services except idm and idp. These are replaced by external services.
       OC_EXCLUDE_RUN_SERVICES: idm,idp
@@ -47,7 +47,7 @@ services:
       OC_LDAP_DISABLE_USER_MECHANISM: "attribute"
       OC_ADMIN_USER_ID: ""
       SETTINGS_SETUP_DEFAULT_ASSIGNMENTS: "false"
-      GRAPH_ASSIGN_DEFAULT_USER_ROLE: "false"
+      GRAPH_ASSIGN_DEFAULT_USER_ROLE: ${GRAPH_ASSIGN_DEFAULT_USER_ROLE:-false}
       GRAPH_USERNAME_MATCH: "none"
       # We need to set the IDP_DOMAIN to allow the CSP rules to be set correctly
       IDP_DOMAIN: ${IDP_DOMAIN:-keycloak.opencloud.test}


### PR DESCRIPTION
Allow PROXY_ROLE_ASSIGNMENT_DRIVER to be set via environment variable in .env file, with oidc remaining as the default value. 

I was frustrated that this was hard coded since my OIDC doesn't offer the complete roles scope, so I made it configurable to allow the default auto-assign.