### PR TITLE
add the default language variable to the docker-compose.yaml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,11 @@ OC_DATA_DIR=
 # Example: curl -L https://github.com/opencloud-eu/web-extensions/releases/download/unzip-v1.0.2/unzip-1.0.2.zip -o config/opencloud/apps/unzip-1.0.2.zip && unzip config/opencloud/apps/unzip-1.0.2.zip -d config/opencloud/apps && rm config/opencloud/apps/unzip-1.0.2.zip 
 # NOTE: you need to restart the openCloud container to load the new extensions.
 #OC_APPS_DIR=/your/local/opencloud/apps
+#
+# The default language used by services and the WebUI.
+# Uses ISO 639-1 language codes (e.g. "en", "de", "fr").
+# Defaults to English if not set.
+DEFAULT_LANGUAGE=
 
 # Define the ldap-server storage location. Set the paths for config and data to a local path.
 # Leaving it default stores data in docker internal volumes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       OC_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS: "${OC_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS:-1}"
       OC_PASSWORD_POLICY_MIN_DIGITS: "${OC_PASSWORD_POLICY_MIN_DIGITS:-1}"
       OC_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS: "${OC_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS:-1}"
-      # default language for services/WebUI; defaults to English
+      # default language for services/WebUI; defaults to English, language code (ISO 639-1, e.g. de, en, fr)
       OC_DEFAULT_LANGUAGE: ${DEFAULT_LANGUAGE}
     volumes:
       - ./config/opencloud/csp.yaml:/etc/opencloud/csp.yaml


### PR DESCRIPTION
I added `OC_DEFAULT_LANGUAGE` to the docker-compose.yaml so you can change via .env the default language 

With documentation this will solve:
https://github.com/opencloud-eu/opencloud/issues/2081 
