### PR TITLE
update certs.yml example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,10 +59,7 @@ TRAEFIK_SERVICES_TLS_CONFIG="tls.certresolver=letsencrypt"
 #     - certFile: /certs/opencloud.test.crt
 #       keyFile: /certs/opencloud.test.key
 #   stores:
-#     default:
-#       defaultCertificate:
-#         certFile: /certs/opencloud.test.crt
-#         keyFile: /certs/opencloud.test.key
+#     - default
 #
 # The certificates need to be copied into ./certs/, the absolute path inside the container is /certs/.
 # You can also use TRAEFIK_CERTS_DIR=/path/on/host to set the path to the certificates directory.

--- a/README.md
+++ b/README.md
@@ -285,10 +285,6 @@ OpenCloud Compose supports adding SSL certificates for public domains and develo
          keyFile: /certs/opencloud.test.key
          stores:
            - default
-       - certFile: /certs/wildcard.example.com.crt
-         keyFile: /certs/wildcard.example.com.key
-         stores:
-           - default
    ```
 
 3. **Configure environment variables**:


### PR DESCRIPTION
fix https://github.com/opencloud-eu/opencloud-compose/issues/191

tested using https://github.com/opencloud-eu/qa/blob/main/.github/ISSUE_TEMPLATE/docker-compose_test_plan_template.md#test-92-custom-certificate-configuration-development
and 

certs.yml
```
tls:
     certificates:
       - certFile: /certs/opencloud.test.crt
         keyFile: /certs/opencloud.test.key
         stores:
           - default
```

works fine. 

@schweigisito I can't explain why it didn't work before, but now everything is fine.