### PR TITLE
Add healthchecks and minor service improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,9 @@ TRAEFIK_LOG_LEVEL=
 # Don't use ports in the range of 8000-9999 and 5232 as those ports are used internally and therefore might create conflicts.
 #TRAEFIK_PORT_HTTP=4080
 #TRAEFIK_PORT_HTTPS=4443
+# Defaults to "/var/run/docker.sock". 
+# Set to "/run/user/1000/docker.sock" if Docker is running in rootless mode (https://docs.docker.com/engine/security/rootless/).
+#DOCKER_SOCKET_PATH=
 
 ## OpenCloud Settings ##
 # The opencloud container image.

--- a/.env.example
+++ b/.env.example
@@ -317,7 +317,7 @@ IDP_ACCOUNT_URL=
 ## Shared User Directory Mode ##
 # Use together with idm/ldap-keycloak.yml and traefik/ldap-keycloak.yml
 # Domain for Keycloak. Defaults to "keycloak.opencloud.test".
-KEYCLOAK_DOMAIN=
+KC_DOMAIN=
 # Bootstrap admin user login name. Defaults to "kcadmin".
 KC_BOOTSTRAP_ADMIN_USERNAME=
 # Bootstrap admin user login password. Defaults to "admin".

--- a/.env.example
+++ b/.env.example
@@ -318,10 +318,10 @@ IDP_ACCOUNT_URL=
 # Use together with idm/ldap-keycloak.yml and traefik/ldap-keycloak.yml
 # Domain for Keycloak. Defaults to "keycloak.opencloud.test".
 KEYCLOAK_DOMAIN=
-# Admin user login name. Defaults to "kcadmin".
-KEYCLOAK_ADMIN=
-# Admin user login password. Defaults to "admin".
-KEYCLOAK_ADMIN_PASSWORD=
+# Bootstrap admin user login name. Defaults to "kcadmin".
+KC_BOOTSTRAP_ADMIN_USERNAME=
+# Bootstrap admin user login password. Defaults to "admin".
+KC_BOOTSTRAP_ADMIN_PASSWORD=
 # Configure the log level for Keycloak.
 # Possible values are "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" and "OFF". Default is "INFO".
 KC_LOG_LEVEL=

--- a/README.md
+++ b/README.md
@@ -344,8 +344,8 @@ Key variables:
 | `WOPISERVER_DOMAIN`           | WOPI server domain                                    | wopiserver.opencloud.test    |
 | `TIKA_IMAGE`                  | Apache Tika image tag                                 | apache/tika:slim             |
 | `KEYCLOAK_DOMAIN`             | Keycloak domain                                       | keycloak.opencloud.test      |
-| `KEYCLOAK_ADMIN`              | Keycloak admin username                               | kcadmin                      |
-| `KEYCLOAK_ADMIN_PASSWORD`     | Keycloak admin password                               | admin                        |
+| `KC_BOOTSTRAP_ADMIN_USERNAME`              | Keycloak bootstrap admin username                               | kcadmin                      |
+| `KC_BOOTSTRAP_ADMIN_PASSWORD`     | Keycloak boostrap admin password                               | admin                        |
 | `LDAP_BIND_PASSWORD`          | LDAP password for the bind user                       | admin                        |
 | `KC_DB_USERNAME`              | Database user for keycloak                            | keycloak                     |
 | `KC_DB_PASSWORD`              | Database password for keycloak                        | keycloak                     |

--- a/README.md
+++ b/README.md
@@ -343,9 +343,9 @@ Key variables:
 | `COLLABORA_DOMAIN`            | Collabora domain                                      | collabora.opencloud.test     |
 | `WOPISERVER_DOMAIN`           | WOPI server domain                                    | wopiserver.opencloud.test    |
 | `TIKA_IMAGE`                  | Apache Tika image tag                                 | apache/tika:slim             |
-| `KEYCLOAK_DOMAIN`             | Keycloak domain                                       | keycloak.opencloud.test      |
-| `KC_BOOTSTRAP_ADMIN_USERNAME`              | Keycloak bootstrap admin username                               | kcadmin                      |
-| `KC_BOOTSTRAP_ADMIN_PASSWORD`     | Keycloak boostrap admin password                               | admin                        |
+| `KC_DOMAIN`                   | Keycloak domain                                       | keycloak.opencloud.test      |
+| `KC_BOOTSTRAP_ADMIN_USERNAME` | Keycloak bootstrap admin username                     | kcadmin                      |
+| `KC_BOOTSTRAP_ADMIN_PASSWORD` | Keycloak boostrap admin password                      | admin                        |
 | `LDAP_BIND_PASSWORD`          | LDAP password for the bind user                       | admin                        |
 | `KC_DB_USERNAME`              | Database user for keycloak                            | keycloak                     |
 | `KC_DB_PASSWORD`              | Database password for keycloak                        | keycloak                     |

--- a/config/keycloak/docker-entrypoint-override.sh
+++ b/config/keycloak/docker-entrypoint-override.sh
@@ -4,7 +4,7 @@ log_level=$(printf '%s' "$KC_LOG_LEVEL" | tr '[:upper:]' '[:lower:]')
 case "$log_level" in trace|debug) printenv ;; *) ;; esac
 
 # replace openCloud domain and LDAP password in keycloak realm import
-mkdir /opt/keycloak/data/import
+mkdir -p /opt/keycloak/data/import
 sed -e "s/cloud.opencloud.test/${OC_DOMAIN}/g" -e "s/ldap-admin-password/${LDAP_ADMIN_PASSWORD:-admin}/g" /opt/keycloak/data/import-dist/openCloud-realm.json > /opt/keycloak/data/import/openCloud-realm.json
 
 # run original docker-entrypoint

--- a/config/traefik/docker-entrypoint-override.sh
+++ b/config/traefik/docker-entrypoint-override.sh
@@ -13,6 +13,8 @@ TRAEFIK_CMD="traefik"
 add_arg "--log.level=${TRAEFIK_LOG_LEVEL:-ERROR}"
 # enable dashboard
 add_arg "--api.dashboard=true"
+# enable ping for healthchecks
+add_arg "--ping=true"
 # define entrypoints
 add_arg "--entryPoints.http.address=:${TRAEFIK_PORT_HTTP:-80}"
 add_arg "--entryPoints.http.http.redirections.entryPoint.to=https"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,12 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:9205/healthz"]
+      start_period: 5s
+      interval: 15s
+      timeout: 5s
+      retries: 5
 
 volumes:
   opencloud-config:

--- a/idm/external-idp.yml
+++ b/idm/external-idp.yml
@@ -66,6 +66,12 @@ services:
       - ${LDAP_CERTS_DIR:-ldap-certs}:/opt/bitnami/openldap/share
       - ${LDAP_DATA_DIR:-ldap-data}:/bitnami/openldap
     restart: always
+    healthcheck:
+      test: ["CMD", "ldapwhoami", "-x", "-H", "ldap://localhost:1389"]
+      start_period: 30s
+      interval: 15s
+      timeout: 5s
+      retries: 5
 
 volumes:
   ldap-certs:

--- a/idm/ldap-keycloak.yml
+++ b/idm/ldap-keycloak.yml
@@ -23,19 +23,19 @@ services:
       # Keycloak IDP specific configuration
       PROXY_AUTOPROVISION_ACCOUNTS: "false"
       PROXY_ROLE_ASSIGNMENT_DRIVER: "oidc"
-      OC_OIDC_ISSUER: https://${KEYCLOAK_DOMAIN:-keycloak.opencloud.test}/realms/openCloud
+      OC_OIDC_ISSUER: https://${KC_DOMAIN:-keycloak.opencloud.test}/realms/openCloud
       PROXY_OIDC_REWRITE_WELLKNOWN: "true"
       WEB_OIDC_CLIENT_ID: ${OC_OIDC_CLIENT_ID:-web}
       PROXY_USER_OIDC_CLAIM: "uuid"
       PROXY_USER_CS3_CLAIM: "userid"
-      WEB_OPTION_ACCOUNT_EDIT_LINK_HREF: "https://${KEYCLOAK_DOMAIN:-keycloak.opencloud.test}/realms/openCloud/account"
+      WEB_OPTION_ACCOUNT_EDIT_LINK_HREF: "https://${KC_DOMAIN:-keycloak.opencloud.test}/realms/openCloud/account"
       # admin and demo accounts must be created in Keycloak
       OC_ADMIN_USER_ID: ""
       SETTINGS_SETUP_DEFAULT_ASSIGNMENTS: "false"
       GRAPH_ASSIGN_DEFAULT_USER_ROLE: "false"
       GRAPH_USERNAME_MATCH: "none"
       # This is needed to set the correct CSP rules for OpenCloud
-      IDP_DOMAIN: ${KEYCLOAK_DOMAIN:-keycloak.opencloud.test}
+      IDP_DOMAIN: ${KC_DOMAIN:-keycloak.opencloud.test}
 
   ldap-server:
     image: bitnamilegacy/openldap:2.6
@@ -90,7 +90,7 @@ services:
     environment:
       LDAP_ADMIN_PASSWORD: ${LDAP_BIND_PASSWORD:-admin}
       OC_DOMAIN: ${OC_DOMAIN:-cloud.opencloud.test}
-      KC_HOSTNAME: ${KEYCLOAK_DOMAIN:-keycloak.opencloud.test}
+      KC_HOSTNAME: ${KC_DOMAIN:-keycloak.opencloud.test}
       KC_DB: postgres
       KC_DB_URL: "jdbc:postgresql://postgres:5432/keycloak"
       KC_DB_USERNAME: ${KC_DB_USERNAME:-keycloak}

--- a/idm/ldap-keycloak.yml
+++ b/idm/ldap-keycloak.yml
@@ -65,6 +65,7 @@ services:
 
   postgres:
     image: postgres:17-alpine
+    user: postgres
     networks:
       opencloud-net:
     volumes:

--- a/idm/ldap-keycloak.yml
+++ b/idm/ldap-keycloak.yml
@@ -62,6 +62,12 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
+    healthcheck:
+      test: ["CMD", "ldapwhoami", "-x", "-H", "ldap://localhost:1389"]
+      start_period: 30s
+      interval: 15s
+      timeout: 5s
+      retries: 5
 
   postgres:
     image: postgres:17-alpine
@@ -77,6 +83,12 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${KC_DB_USERNAME}"]
+      start_period: 5s
+      interval: 15s
+      timeout: 5s
+      retries: 5
 
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.3
@@ -107,6 +119,15 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
+    healthcheck:
+      test: >
+        bash -c "exec 3<>/dev/tcp/localhost/8080 &&
+        printf 'GET /realms/openCloud/.well-known/openid-configuration HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 &&
+        head -n1 <&3 | grep -qE '200 OK'"
+      start_period: 30s
+      interval: 15s
+      timeout: 5s
+      retries: 5
 
 volumes:
   keycloak_postgres_data:

--- a/idm/ldap-keycloak.yml
+++ b/idm/ldap-keycloak.yml
@@ -99,8 +99,8 @@ services:
       KC_LOG_LEVEL: ${KC_LOG_LEVEL:-INFO}
       KC_PROXY_HEADERS: xforwarded
       KC_HTTP_ENABLED: true
-      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-kcadmin}
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_BOOTSTRAP_ADMIN_USERNAME:-kcadmin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_BOOTSTRAP_ADMIN_PASSWORD:-admin}
     depends_on:
       - postgres
     logging:

--- a/radicale/radicale.yml
+++ b/radicale/radicale.yml
@@ -15,5 +15,12 @@ services:
     volumes:
       - ./config/radicale/config:/etc/radicale/config
       - ${RADICALE_DATA_DIR:-radicale-data}:/var/lib/radicale
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "-O-", "--no-cache", "http://localhost:5232"]
+      start_period: 5s
+      interval: 10s
+      timeout: 15s
+      retries: 3
+
 volumes:
   radicale-data:

--- a/search/tika.yml
+++ b/search/tika.yml
@@ -11,6 +11,15 @@ services:
     restart: always
     logging:
       driver: ${LOG_DRIVER:-local}
+    healthcheck:
+      test: >
+        bash -c "exec 3<>/dev/tcp/localhost/9998 &&
+        printf 'GET /tika HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 &&
+        head -n1 <&3 | grep -qE '200 OK'"
+      start_period: 10s
+      interval: 15s
+      timeout: 5s
+      retries: 3
 
   opencloud:
     environment:

--- a/testing/external-keycloak.yml
+++ b/testing/external-keycloak.yml
@@ -35,8 +35,8 @@ services:
       KC_LOG_LEVEL: ${KC_LOG_LEVEL:-INFO}
       KC_PROXY_HEADERS: xforwarded
       KC_HTTP_ENABLED: true
-      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-kcadmin}
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_BOOTSTRAP_ADMIN_USERNAME:-kcadmin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_BOOTSTRAP_ADMIN_PASSWORD:-admin}
     depends_on:
       - postgres
     logging:

--- a/testing/external-keycloak.yml
+++ b/testing/external-keycloak.yml
@@ -14,6 +14,12 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${KC_DB_USERNAME}"]
+      start_period: 5s
+      interval: 15s
+      timeout: 5s
+      retries: 5
 
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.3
@@ -43,6 +49,15 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
+    healthcheck:
+      test: >
+        bash -c "exec 3<>/dev/tcp/localhost/8080 &&
+        printf 'GET /realms/openCloud/.well-known/openid-configuration HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 &&
+        head -n1 <&3 | grep -qE '200 OK'"
+      start_period: 30s
+      interval: 15s
+      timeout: 5s
+      retries: 5
 
 volumes:
   keycloak_postgres_data:

--- a/testing/external-keycloak.yml
+++ b/testing/external-keycloak.yml
@@ -2,6 +2,7 @@
 services:
   postgres:
     image: postgres:17-alpine
+    user: postgres
     networks:
       opencloud-net:
     volumes:

--- a/testing/external-keycloak.yml
+++ b/testing/external-keycloak.yml
@@ -26,7 +26,7 @@ services:
       - "./config/keycloak/themes/opencloud:/opt/keycloak/themes/opencloud"
     environment:
       OC_DOMAIN: ${OC_DOMAIN:-cloud.opencloud.test}
-      KC_HOSTNAME: ${KEYCLOAK_DOMAIN:-keycloak.opencloud.test}
+      KC_HOSTNAME: ${KC_DOMAIN:-keycloak.opencloud.test}
       KC_DB: postgres
       KC_DB_URL: "jdbc:postgresql://postgres:5432/keycloak"
       KC_DB_USERNAME: ${KC_DB_USERNAME:-keycloak}

--- a/testing/ldap-manager.yml
+++ b/testing/ldap-manager.yml
@@ -22,3 +22,9 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/login"]
+      start_period: 5s
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/traefik/ldap-keycloak.yml
+++ b/traefik/ldap-keycloak.yml
@@ -4,12 +4,12 @@ services:
     networks:
       opencloud-net:
         aliases:
-          - ${KEYCLOAK_DOMAIN:-keycloak.opencloud.test}
+          - ${KC_DOMAIN:-keycloak.opencloud.test}
   keycloak:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.keycloak.entrypoints=https"
-      - "traefik.http.routers.keycloak.rule=Host(`${KEYCLOAK_DOMAIN:-keycloak.opencloud.test}`)"
+      - "traefik.http.routers.keycloak.rule=Host(`${KC_DOMAIN:-keycloak.opencloud.test}`)"
       - "traefik.http.routers.keycloak.${TRAEFIK_SERVICES_TLS_CONFIG}"
       - "traefik.http.routers.keycloak.service=keycloak"
       - "traefik.http.services.keycloak.loadbalancer.server.port=8080"

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -45,3 +45,9 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      start_period: 30s
+      interval: 15s
+      timeout: 5s
+      retries: 3

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -46,6 +46,12 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
+    healthcheck:
+      test: [ "CMD", "opencloud", "collaboration", "health" ]
+      start_period: 5s
+      interval: 15s
+      timeout: 10s
+      retries: 3
 
   collabora:
     image: collabora/code:25.04.7.1.1
@@ -78,7 +84,7 @@ services:
     entrypoint: [ '/bin/bash', '-c' ]
     command: [ 'coolconfig generate-proof-key && /start-collabora-online.sh' ]
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:9980/hosting/discovery" ]
+      test: [ "CMD", "curl", "--fail", "http://localhost:9980/hosting/discovery" ]
       interval: 15s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary
Added healthchecks for all services (`collabora` already had one). Timing values for healthchecks may be adjusted.

## Other changes
* Keycloak environment variable renamings due to deprecation and naming inconsistencies.
* Security improvement (use `postgres` user in `postgres` service).
* Documentation update for rootless Docker setup.

## Breaking changes
Involves renaming the following environment variables:
* KEYCLOAK_ADMIN → KC_BOOTSTRAP_ADMIN_USERNAME
* KEYCLOAK_ADMIN_PASSWORD → KC_BOOTSTRAP_ADMIN_PASSWORD
* KEYCLOAK_DOMAIN → KC_DOMAIN