### PR TITLE
fix: add back slash to traefik allowed encoded characters

### DIFF
--- a/config/traefik/docker-entrypoint-override.sh
+++ b/config/traefik/docker-entrypoint-override.sh
@@ -24,13 +24,13 @@ add_arg "--entryPoints.https.transport.respondingTimeouts.readTimeout=12h"
 add_arg "--entryPoints.https.transport.respondingTimeouts.writeTimeout=12h"
 add_arg "--entryPoints.https.transport.respondingTimeouts.idleTimeout=3m"
 # allow encoded characters
-# required for WOPI/Collabora
+# required for WOPI/Collabora and  file operations with supported encoded characters
 add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedSlash=true"
 add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedQuestionMark=true"
 add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedPercent=true"
-# required for file operations with supported encoded characters
 add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedSemicolon=true"
 add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedHash=true"
+add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedBackSlash=true"
 # docker provider (get configuration from container labels)
 add_arg "--providers.docker.endpoint=unix:///var/run/docker.sock"
 add_arg "--providers.docker.exposedByDefault=false"


### PR DESCRIPTION
Fixes https://github.com/opencloud-eu/web/issues/1893