### PR TITLE
chore: bump traefik to 3.6.7

### DIFF
--- a/config/traefik/docker-entrypoint-override.sh
+++ b/config/traefik/docker-entrypoint-override.sh
@@ -23,14 +23,6 @@ add_arg "--entryPoints.https.address=:${TRAEFIK_PORT_HTTPS:-443}"
 add_arg "--entryPoints.https.transport.respondingTimeouts.readTimeout=12h"
 add_arg "--entryPoints.https.transport.respondingTimeouts.writeTimeout=12h"
 add_arg "--entryPoints.https.transport.respondingTimeouts.idleTimeout=3m"
-# allow encoded characters
-# required for WOPI/Collabora and  file operations with supported encoded characters
-add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedSlash=true"
-add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedQuestionMark=true"
-add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedPercent=true"
-add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedSemicolon=true"
-add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedHash=true"
-add_arg "--entryPoints.https.http.encodedCharacters.allowEncodedBackSlash=true"
 # docker provider (get configuration from container labels)
 add_arg "--providers.docker.endpoint=unix:///var/run/docker.sock"
 add_arg "--providers.docker.exposedByDefault=false"

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -9,7 +9,7 @@ services:
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
       - "traefik.http.routers.opencloud.${TRAEFIK_SERVICES_TLS_CONFIG}"
   traefik:
-    image: traefik:v3.6.4
+    image: traefik:v3.6.7
     # release notes: https://github.com/traefik/traefik/releases
     user: ${TRAEFIK_CONTAINER_UID_GID:-0:0}
     networks:


### PR DESCRIPTION
Also removed the allowedCharacters traefik config section as traefik stepped back 