### PR TITLE
fix: slow kit jail error server audit in collabora (next try)

### DIFF
--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -48,7 +48,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:25.04.7.1.1
+    image: collabora/code:25.04.9.1.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       opencloud-net:


### PR DESCRIPTION
The upstream issue as been fixed (https://github.com/CollaboraOnline/online/issues/12331). Let's turn this on again.