### PR TITLE
keycloak theme fixes

### DIFF
--- a/config/keycloak/themes/opencloud/login/resources/css/theme.css
+++ b/config/keycloak/themes/opencloud/login/resources/css/theme.css
@@ -28,11 +28,16 @@ body {
 .kc-logo-text {
     background-image: url(../img/logo.svg) !important;
     background-size: contain;
-    width: 400px;
-    margin: 0 !important;
+    background-position: center;
 }
 
-#kc-header-wrapper{
+#kc-header-wrapper {
     display: flex;
     justify-content: center;
+}
+
+@media (max-width: 767px) {
+    #kc-header-wrapper {
+        padding: 20px 60px 0;
+    }
 }

--- a/config/keycloak/themes/opencloud/login/resources/css/theme.css
+++ b/config/keycloak/themes/opencloud/login/resources/css/theme.css
@@ -44,5 +44,8 @@ body {
 
 .pf-c-button.pf-m-secondary {
     color: var(--pf-global--Color--light-100) !important;
+}
+
+.kc-margin-top {
     margin-top: var(--pf-global--spacer--sm);
 }

--- a/config/keycloak/themes/opencloud/login/resources/css/theme.css
+++ b/config/keycloak/themes/opencloud/login/resources/css/theme.css
@@ -41,3 +41,8 @@ body {
         padding: 20px 60px 0;
     }
 }
+
+.pf-c-button.pf-m-secondary {
+    color: var(--pf-global--Color--light-100) !important;
+    margin-top: var(--pf-global--spacer--sm);
+}

--- a/config/keycloak/themes/opencloud/login/theme.properties
+++ b/config/keycloak/themes/opencloud/login/theme.properties
@@ -3,3 +3,5 @@ import=common/keycloak
 
 styles=css/login.css css/theme.css
 scripts=js/script.js
+
+kcButtonSecondaryClass=pf-c-button pf-m-secondary btn-lg

--- a/config/keycloak/themes/opencloud/login/theme.properties
+++ b/config/keycloak/themes/opencloud/login/theme.properties
@@ -5,3 +5,4 @@ styles=css/login.css css/theme.css
 scripts=js/script.js
 
 kcButtonSecondaryClass=pf-c-button pf-m-secondary btn-lg
+kcMarginTopClass=kc-margin-top


### PR DESCRIPTION
PR addresses two parts.

1. opencloud logo is off-centered in mobile view. This is now fixed by ensuring symmetrical padding.

<img width="405" height="336" alt="image" src="https://github.com/user-attachments/assets/486dc251-0581-496a-a1b6-15de4741d4fd" />
<img width="392" height="339" alt="image" src="https://github.com/user-attachments/assets/5df7db11-a268-415c-8b02-09a2f2841186" />
<p/><p/>

2. If passkeys which are supported since kc 26.4 are enabled, the sign in button is shown as an unstyled link, which is in contrast to the styled one found in the `keycloak.v2` login theme.

<img width="542" height="361" alt="image" src="https://github.com/user-attachments/assets/a5307509-6c5e-45ca-b8fe-4c6f7ec3c6c5" />
<img width="541" height="371" alt="image" src="https://github.com/user-attachments/assets/1959ae68-3b63-420a-a191-c9342d6b1cce" />
<p/><p/>

<details><summary>Reference: keycloak.v2 theme</summary>
<p>
<img width="566" height="522" alt="image" src="https://github.com/user-attachments/assets/041099ca-54a1-406b-974d-b76de83abe0a" />
</p>
</details> 


This is because the keycloak theme which opencloud used as a base has been deprecated and no longer receives support. We fix this by defining the classes and styles required by the passkeys button.
Note: it's a bandaid fix for as long as we depend on the old theme which [could](https://www.keycloak.org/2024/10/keycloak-2600-released#_new_default_login_theme) be removed in the future.

