### PR TITLE
Update OC_DOCKER_TAG comment in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,7 +85,7 @@ TRAEFIK_LOG_LEVEL=
 # Defaults to production if not set otherwise
 OC_DOCKER_IMAGE=opencloudeu/opencloud-rolling
 # The openCloud container version.
-# Defaults to "latest" and points to the latest stable tag.
+# Defaults to the latest version-tag. Use git pull to update.
 OC_DOCKER_TAG=
 # The default id used in opencloud containers is 1000 for user and group.
 # If you want to change the default, use the following variable and the format [UID]:[GID].


### PR DESCRIPTION
Updated comment for OC_DOCKER_TAG as it does not default to "latest".