### PR TITLE
add optional demo users for ldap-keycloak setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -330,6 +330,18 @@ KC_DB_USERNAME=
 # Keycloak Database password. Defaults to "keycloak".
 KC_DB_PASSWORD=
 
+## Demo Users ##
+# Enable demo users and groups in the shared LDAP directory.
+# To enable, create custom/ldap-keycloak-demo-users.yml with:
+#   services:
+#     ldap-server:
+#       volumes:
+#         - ./config/ldap/ldif/30_demo_users.ldif:/ldifs/30_demo_users.ldif
+#         - ./config/ldap/ldif/40_demo_groups.ldif:/ldifs/40_demo_groups.ldif
+#
+# Then add it to: COMPOSE_FILE=docker-compose.yml:weboffice/collabora.yml:traefik/opencloud.yml:traefik/collabora.yml:idm/ldap-keycloak.yml:traefik/ldap-keycloak.yml:custom/ldap-keycloak-demo-users.yml
+# WARNING: Do not use in production.
+
 ### Radicale Setting ###
 # Radicale is a small open-source CalDAV (calendars, to-do lists) and CardDAV (contacts) server.
 # When enabled OpenCloud is configured as a reverse proxy for Radicale, providing all authenticated


### PR DESCRIPTION
we had https://github.com/opencloud-eu/opencloud-compose/blob/main/config/ldap/ldif/30_demo_users.ldif but never used it

this PR added optional demo users for `ldap-keycloak` example setup. Now you can add `idm/ldap-keycloak-demo-users.yml` to enable demo users/groups 