### PR TITLE
feat: add authelia example use for authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ INSECURE=true
 #COMPOSE_FILE=docker-compose.yml:weboffice/collabora.yml:traefik/opencloud.yml:traefik/collabora.yml:idm/ldap-keycloak.yml:traefik/ldap-keycloak.yml
 # External IDP
 #COMPOSE_FILE=docker-compose.yml:weboffice/collabora.yml:traefik/opencloud.yml:traefik/collabora.yml:idm/external-idp.yml
+# Authelia + LLDAP Shared User Directory
+#COMPOSE_FILE=docker-compose.yml:traefik/opencloud.yml:idm/authelia-lldap.yml:traefik/authelia-lldap.yml
+# External Authelia
+#COMPOSE_FILE=docker-compose.yml:traefik/opencloud.yml:idm/external-authelia.yml
 
 ## Traefik Settings ##
 # Note: Traefik is always enabled and can't be disabled.
@@ -329,6 +333,40 @@ KC_LOG_LEVEL=
 KC_DB_USERNAME=
 # Keycloak Database password. Defaults to "keycloak".
 KC_DB_PASSWORD=
+
+## Authelia + LLDAP ##
+# Use together with idm/authelia-lldap.yml and traefik/authelia-lldap.yml
+# Domain for the Authelia authentication portal. Defaults to "auth.opencloud.test".
+AUTHELIA_DOMAIN=
+# Domain for the LLDAP web admin interface. Defaults to "lldap.opencloud.test".
+LLDAP_DOMAIN=
+# Admin password for LLDAP (and used by Authelia to query LDAP).
+# NOTE: This variable needs to be set before the first start. Changes after first start will be IGNORED.
+LLDAP_ADMIN_PASSWORD=
+# JWT secret used by LLDAP to sign session tokens.
+# Generate with: openssl rand -hex 32
+LLDAP_JWT_SECRET=
+# Secret used by Authelia for JWT-based password reset tokens.
+# Generate with: openssl rand -hex 32
+AUTHELIA_JWT_SECRET=
+# Secret used by Authelia to encrypt the session cookie.
+# Generate with: openssl rand -hex 32
+AUTHELIA_SESSION_SECRET=
+# Secret used by Authelia to encrypt the SQLite database.
+# Generate with: openssl rand -hex 32
+AUTHELIA_STORAGE_ENCRYPTION_KEY=
+# HMAC secret used by Authelia to sign OIDC tokens.
+# Generate with: openssl rand -hex 32
+AUTHELIA_OIDC_HMAC_SECRET=
+
+## External Authelia ##
+# Use together with idm/external-authelia.yml when you already have a running Authelia instance.
+# Domain of your external Authelia instance (without https://).
+# Example: "auth.example.com"
+#IDP_DOMAIN=
+# Full Authelia base URL used as the OIDC issuer.
+# Example: "https://auth.example.com"
+#IDP_ISSUER_URL=
 
 ## Demo Users ##
 # Enable demo users and groups in the shared LDAP directory.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,78 @@ This setup includes:
 - Shared LDAP server as a user directory with demo users and groups
 - Integration with Keycloak using OpenCloud clients (`web`, `OpenCloudDesktop`, `OpenCloudAndroid`, `OpenCloudIOS`)
 
+### With Authelia and LLDAP
+
+OpenCloud can be deployed with [Authelia](https://www.authelia.com/) as the authentication portal and [LLDAP](https://github.com/lldap/lldap) as a lightweight LDAP user directory:
+
+> **DNS Requirements**: This setup requires DNS entries for the OpenCloud domain, the Authelia domain, and the LLDAP admin domain. Configure DNS A/AAAA records (e.g., `cloud.example.com`, `auth.example.com`, `lldap.example.com`) or use a wildcard DNS entry (`*.example.com`).
+
+Using `-f` flags:
+```bash
+docker compose -f docker-compose.yml -f idm/authelia-lldap.yml -f traefik/opencloud.yml -f traefik/authelia-lldap.yml up -d
+```
+
+Or by setting in `.env`:
+```
+COMPOSE_FILE=docker-compose.yml:idm/authelia-lldap.yml:traefik/opencloud.yml:traefik/authelia-lldap.yml
+```
+
+Configure the required secrets in your `.env` file (generate each with `openssl rand -hex 32`):
+```ini
+AUTHELIA_DOMAIN=auth.example.com
+LLDAP_DOMAIN=lldap.example.com
+LLDAP_ADMIN_PASSWORD=your_lldap_admin_password
+LLDAP_JWT_SECRET=
+AUTHELIA_JWT_SECRET=
+AUTHELIA_SESSION_SECRET=
+AUTHELIA_STORAGE_ENCRYPTION_KEY=
+AUTHELIA_OIDC_HMAC_SECRET=
+```
+
+> **For local development only**: Add to `/etc/hosts`:
+> ```
+> 127.0.0.1 auth.opencloud.test
+> 127.0.0.1 lldap.opencloud.test
+> ```
+
+This setup includes:
+- Authelia as a self-hosted authentication portal with 2FA (TOTP and WebAuthn)
+- LLDAP as a lightweight LDAP server for managing users and groups
+- Redis session persistence 
+- OIDC integration with OpenCloud web, desktop, iOS, and Android clients
+
+**First-time admin setup:**
+
+Before starting, you must create at least one user in LLDAP. After the stack is up, navigate to `https://lldap.example.com` (or `http://localhost:17170` if using the external proxy variant) and:
+
+1. Log in with `admin` and the `LLDAP_ADMIN_PASSWORD` you set
+2. Create a group named `opencloud-admin`
+3. Create your admin user and add them to the `opencloud-admin` group
+
+Then follow the role-assignment bootstrap steps described in `idm/authelia-lldap.yml` to enable the OIDC role mapping: uncomment and adjust the block at the top of `config/opencloud/proxy.yaml`, setting `claim_value` to your admin group name.
+
+**OIDC JWKS key**: The RSA private key used to sign OIDC tokens is automatically generated on first startup and persisted in the `authelia-config` Docker volume. No manual key generation is required.
+
+### With External Authelia
+
+If you already have a running Authelia instance, use the external variant. Configure your Authelia instance with the OIDC clients from `config/authelia/configuration.dist.yml` and point OpenCloud at it:
+
+Using `-f` flags:
+```bash
+docker compose -f docker-compose.yml -f idm/external-authelia.yml -f traefik/opencloud.yml up -d
+```
+
+Or by setting in `.env`:
+```
+COMPOSE_FILE=docker-compose.yml:idm/external-authelia.yml:traefik/opencloud.yml
+```
+
+Set in `.env`:
+```ini
+IDP_DOMAIN=auth.example.com
+IDP_ISSUER_URL=https://auth.example.com
+```
+
 ### With Collabora Online
 
 Include Collabora for document editing using either method:

--- a/config/authelia/configuration.dist.yml
+++ b/config/authelia/configuration.dist.yml
@@ -1,0 +1,181 @@
+---
+# Authelia configuration template for OpenCloud + LLDAP integration.
+# This file is processed by Authelia's Go template engine (X_AUTHELIA_CONFIG_FILTERS=template).
+# Environment variables referenced here are passed into the authelia container.
+
+theme: auto
+default_2fa_method: totp
+
+server:
+  address: tcp://0.0.0.0:9091/
+
+log:
+  level: warn
+
+totp:
+  disable: false
+  issuer: '{{ env "AUTHELIA_DOMAIN" }}'
+
+webauthn:
+  disable: false
+  timeout: 60s
+  attestation_conveyance_preference: indirect
+  user_verification: preferred
+
+authentication_backend:
+  ldap:
+    implementation: lldap
+    address: 'ldap://lldap:3890'
+    base_dn: 'dc=opencloud,dc=eu'
+    user: 'uid=admin,ou=people,dc=opencloud,dc=eu'
+    password: '{{ env "LLDAP_ADMIN_PASSWORD" }}'
+
+access_control:
+  default_policy: two_factor
+
+session:
+  name: authelia_session
+  cookies:
+    - domain: '{{ env "AUTHELIA_DOMAIN" }}'
+      authelia_url: 'https://{{ env "AUTHELIA_DOMAIN" }}'
+  expiration: 24h
+  inactivity: 24h
+  remember_me_duration: 30d
+  redis:
+    host: redis
+    port: 6379
+
+regulation:
+  max_retries: 3
+  find_time: 2m
+  ban_time: 5m
+
+storage:
+  local:
+    path: /config/db.sqlite3
+
+notifier:
+  filesystem:
+    filename: /config/notifications.txt
+
+identity_providers:
+  oidc:
+    lifespans:
+      access_token: 1d
+      refresh_token: 30d
+    jwks:
+      - key_id: opencloud
+        algorithm: RS256
+        use: sig
+        key: |
+          {{ secret "/config/secrets/oidc_jwks.pem" | mindent 10 "|" | msquote }}
+    cors:
+      endpoints:
+        - authorization
+        - token
+        - revocation
+        - introspection
+        - userinfo
+      allowed_origins:
+        - 'https://{{ env "OC_DOMAIN" }}'
+      allowed_origins_from_client_redirect_uris: false
+    clients:
+      - client_id: web
+        client_name: OpenCloud Web
+        public: true
+        authorization_policy: two_factor
+        consent_mode: auto
+        pre_configured_consent_duration: 1w
+        scopes:
+          - openid
+          - email
+          - profile
+          - groups
+          - offline_access
+        redirect_uris:
+          - 'https://{{ env "OC_DOMAIN" }}/'
+          - 'https://{{ env "OC_DOMAIN" }}/oidc-callback.html'
+          - 'https://{{ env "OC_DOMAIN" }}/oidc-silent-redirect.html'
+        grant_types:
+          - refresh_token
+          - authorization_code
+        response_types:
+          - code
+        response_modes:
+          - form_post
+          - query
+          - fragment
+        userinfo_signed_response_alg: none
+
+      - client_id: OpenCloudDesktop
+        client_name: OpenCloud Desktop Client
+        public: true
+        authorization_policy: one_factor
+        consent_mode: auto
+        pre_configured_consent_duration: 1w
+        scopes:
+          - openid
+          - groups
+          - profile
+          - email
+          - offline_access
+        redirect_uris:
+          - http://127.0.0.1
+        grant_types:
+          - refresh_token
+          - authorization_code
+        response_types:
+          - code
+        response_modes:
+          - form_post
+        userinfo_signed_response_alg: none
+
+      - client_id: OpenCloudIOS
+        client_name: OpenCloud iOS Client
+        public: true
+        authorization_policy: one_factor
+        consent_mode: auto
+        pre_configured_consent_duration: 1w
+        allow_multiple_auth_methods: true
+        scopes:
+          - openid
+          - groups
+          - profile
+          - email
+          - offline_access
+        redirect_uris:
+          - oc://ios.opencloud.eu
+        grant_types:
+          - refresh_token
+          - authorization_code
+        response_types:
+          - code
+        response_modes:
+          - form_post
+          - query
+        userinfo_signed_response_alg: none
+
+      - client_id: OpenCloudAndroid
+        client_name: OpenCloud Android Client
+        public: true
+        authorization_policy: one_factor
+        consent_mode: auto
+        pre_configured_consent_duration: 1w
+        allow_multiple_auth_methods: true
+        scopes:
+          - openid
+          - groups
+          - profile
+          - email
+          - offline_access
+        redirect_uris:
+          - oc://android.opencloud.eu
+        grant_types:
+          - refresh_token
+          - authorization_code
+        response_types:
+          - code
+        response_modes:
+          - form_post
+          - query
+        userinfo_signed_response_alg: none

--- a/config/authelia/docker-entrypoint-override.sh
+++ b/config/authelia/docker-entrypoint-override.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+SECRETS_DIR=/config/secrets
+JWKS_KEY="${SECRETS_DIR}/oidc_jwks.pem"
+
+mkdir -p "${SECRETS_DIR}"
+
+# Auto-generate the OIDC JWKS RSA private key on first startup if not present.
+# Authelia uses this key to sign OIDC identity tokens.
+if [ ! -f "${JWKS_KEY}" ]; then
+    echo "Generating OIDC JWKS RSA private key..."
+    openssl genrsa -out "${JWKS_KEY}" 4096
+    echo "OIDC JWKS RSA key generated at ${JWKS_KEY}"
+fi
+
+# Hand off to the default Authelia entrypoint
+exec authelia "$@"

--- a/config/opencloud/proxy.yaml
+++ b/config/opencloud/proxy.yaml
@@ -1,3 +1,17 @@
+# Role assignment via OIDC groups (Authelia / external IdP)
+# Uncomment and configure the section below to map a group from your IdP to an OpenCloud role.
+# This is needed when using idm/authelia-lldap.yml or idm/external-authelia.yml.
+# See the bootstrap instructions in idm/authelia-lldap.yml for the full setup procedure.
+#
+# proxy:
+#   role_assignment:
+#     driver: oidc
+#     oidc_role_mapper:
+#       role_claim: groups
+#       role_mapping:
+#         - role_name: admin          # OpenCloud role name
+#           claim_value: opencloud-admin  # group name in LLDAP / your IdP
+
 # This adds four additional routes to the proxy. Forwarding
 # request on '/carddav/', '/caldav/' and the respective '/.well-knwown'
 # endpoints to the radicale container and setting the required headers.

--- a/external-proxy/authelia-exposed.yml
+++ b/external-proxy/authelia-exposed.yml
@@ -1,0 +1,11 @@
+---
+# only expose the ports when you know what you are doing!
+services:
+  authelia:
+    ports:
+      # expose the authelia portal on all interfaces
+      - "0.0.0.0:9091:9091"
+  lldap:
+    ports:
+      # expose the LLDAP web UI on all interfaces
+      - "0.0.0.0:17170:17170"

--- a/external-proxy/authelia.yml
+++ b/external-proxy/authelia.yml
@@ -1,0 +1,10 @@
+---
+services:
+  authelia:
+    ports:
+      # expose the authelia portal on localhost
+      - "127.0.0.1:9091:9091"
+  lldap:
+    ports:
+      # expose the LLDAP web UI on localhost
+      - "127.0.0.1:17170:17170"

--- a/idm/authelia-lldap.yml
+++ b/idm/authelia-lldap.yml
@@ -1,0 +1,116 @@
+---
+services:
+  opencloud:
+    environment:
+      # LLDAP-specific LDAP configuration
+      OC_LDAP_URI: ldap://lldap:3890
+      OC_LDAP_INSECURE: "true"
+      OC_LDAP_BIND_DN: "uid=admin,ou=people,dc=opencloud,dc=eu"
+      OC_LDAP_BIND_PASSWORD: ${LLDAP_ADMIN_PASSWORD:-admin}
+      OC_LDAP_GROUP_BASE_DN: "ou=groups,dc=opencloud,dc=eu"
+      OC_LDAP_GROUP_SCHEMA_ID: "entryUUID"
+      OC_LDAP_USER_BASE_DN: "ou=people,dc=opencloud,dc=eu"
+      OC_LDAP_USER_FILTER: "(objectclass=inetOrgPerson)"
+      OC_LDAP_USER_SCHEMA_ID: "entryUUID"
+      OC_LDAP_DISABLE_USER_MECHANISM: "none"
+      GRAPH_LDAP_SERVER_UUID: "true"
+      GRAPH_LDAP_GROUP_CREATE_BASE_DN: "ou=custom,ou=groups,dc=opencloud,dc=eu"
+      GRAPH_LDAP_REFINT_ENABLED: "false"
+      # User attributes are managed in LLDAP, make them read-only in OpenCloud
+      FRONTEND_READONLY_USER_ATTRIBUTES: "user.onPremisesSamAccountName,user.displayName,user.mail,user.passwordProfile,user.accountEnabled,user.appRoleAssignments"
+      # LLDAP manages the user directory - OpenCloud must not write to it
+      OC_LDAP_SERVER_WRITE_ENABLED: "false"
+      # Disable the built-in identity management and identity provider
+      OC_EXCLUDE_RUN_SERVICES: idm,idp
+      # Authelia OIDC provider configuration
+      OC_OIDC_ISSUER: https://${AUTHELIA_DOMAIN:-auth.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
+      WEB_OIDC_CLIENT_ID: ${OC_OIDC_CLIENT_ID:-web}
+      # Authelia issues opaque access tokens; disable JWT verification
+      PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD: "none"
+      PROXY_OIDC_REWRITE_WELLKNOWN: "true"
+      # Use preferred_username from Authelia as the OpenCloud user identifier
+      PROXY_USER_OIDC_CLAIM: "preferred_username"
+      PROXY_USER_CS3_CLAIM: "username"
+      # Include groups claim for role assignment
+      WEB_OIDC_SCOPE: "openid profile email groups offline_access"
+      PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM: "groups"
+      # No auto-provisioning: users are managed in LLDAP
+      PROXY_AUTOPROVISION_ACCOUNTS: "false"
+      OC_ADMIN_USER_ID: ""
+      SETTINGS_SETUP_DEFAULT_ASSIGNMENTS: "false"
+      GRAPH_ASSIGN_DEFAULT_USER_ROLE: "true"
+      GRAPH_USERNAME_MATCH: "none"
+      # Some clients currently doesn't work when oidc assignment driver is used:
+      # https://github.com/opencloud-eu/desktop/issues/217
+      # That's why you can only use it to bootstrap your admin user currently.
+      #
+      # 1. *Before* first startup: Switch to `PROXY_ROLE_ASSIGNMENT_DRIVER: "oidc"`
+      # 2. Start opencloud container to generate initial config: `docker compose up -d`
+      # 3. Uncomment and adjust the role mapping block in config/opencloud/proxy.yaml:
+      #    Set `claim_value` to the LLDAP group name that should get the `admin` role.
+      #
+      # 4. Restart opencloud container: `docker compose restart opencloud`
+      # 5. Login with your admin user (the one with the `opencloud-admin` group in LLDAP)
+      # 6. Switch back to `PROXY_ROLE_ASSIGNMENT_DRIVER: "default"`
+      # 7. Recreate opencloud container: `docker compose up -d opencloud`
+      PROXY_ROLE_ASSIGNMENT_DRIVER: "default"
+      # Allow Authelia to be embedded in CSP frame/connect directives
+      IDP_DOMAIN: ${AUTHELIA_DOMAIN:-auth.opencloud.test}
+
+  authelia:
+    image: authelia/authelia:latest
+    networks:
+      opencloud-net:
+    entrypoint: ["/bin/sh", "/config/docker-entrypoint-override.sh"]
+    environment:
+      X_AUTHELIA_CONFIG_FILTERS: template
+      AUTHELIA_IDENTITY_VALIDATION_RESET_PASSWORD_JWT_SECRET: ${AUTHELIA_JWT_SECRET:?AUTHELIA_JWT_SECRET must be set}
+      AUTHELIA_SESSION_SECRET: ${AUTHELIA_SESSION_SECRET:?AUTHELIA_SESSION_SECRET must be set}
+      AUTHELIA_STORAGE_ENCRYPTION_KEY: ${AUTHELIA_STORAGE_ENCRYPTION_KEY:?AUTHELIA_STORAGE_ENCRYPTION_KEY must be set}
+      AUTHELIA_IDENTITY_PROVIDERS_OIDC_HMAC_SECRET: ${AUTHELIA_OIDC_HMAC_SECRET:?AUTHELIA_OIDC_HMAC_SECRET must be set}
+      # Pass domain variables so the config template can reference them
+      OC_DOMAIN: ${OC_DOMAIN:-cloud.opencloud.test}
+      AUTHELIA_DOMAIN: ${AUTHELIA_DOMAIN:-auth.opencloud.test}
+      LLDAP_ADMIN_PASSWORD: ${LLDAP_ADMIN_PASSWORD:-admin}
+      TRAEFIK_PORT_HTTPS: ${TRAEFIK_PORT_HTTPS:-}
+    volumes:
+      - authelia-config:/config
+      - "./config/authelia/configuration.dist.yml:/config/configuration.yml:ro"
+      - "./config/authelia/docker-entrypoint-override.sh:/config/docker-entrypoint-override.sh:ro"
+    depends_on:
+      - redis
+      - lldap
+    logging:
+      driver: ${LOG_DRIVER:-local}
+    restart: always
+
+  redis:
+    image: redis:alpine
+    networks:
+      opencloud-net:
+    volumes:
+      - redis-data:/data
+    logging:
+      driver: ${LOG_DRIVER:-local}
+    restart: always
+
+  lldap:
+    image: lldap/lldap:stable
+    networks:
+      opencloud-net:
+    environment:
+      LLDAP_LDAP_BASE_DN: "dc=opencloud,dc=eu"
+      LLDAP_LDAP_USER_DN: "admin"
+      LLDAP_LDAP_USER_PASS: ${LLDAP_ADMIN_PASSWORD:-admin}
+      LLDAP_HTTP_URL: https://${LLDAP_DOMAIN:-lldap.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
+      LLDAP_JWT_SECRET: ${LLDAP_JWT_SECRET:?LLDAP_JWT_SECRET must be set}
+    volumes:
+      - lldap-data:/data
+    logging:
+      driver: ${LOG_DRIVER:-local}
+    restart: always
+
+volumes:
+  authelia-config:
+  redis-data:
+  lldap-data:

--- a/idm/external-authelia.yml
+++ b/idm/external-authelia.yml
@@ -2,35 +2,52 @@
 services:
   opencloud:
     environment:
-      # enable opaque access tokens
+      # Disable the built-in identity management and identity provider
+      OC_EXCLUDE_RUN_SERVICES: idm,idp
+      # External Authelia OIDC provider
+      OC_OIDC_ISSUER: ${IDP_ISSUER_URL:?IDP_ISSUER_URL must be set to your Authelia base URL, e.g. https://auth.example.com}
+      WEB_OIDC_CLIENT_ID: ${OC_OIDC_CLIENT_ID:-web}
+      # Authelia issues opaque access tokens; disable JWT verification
       PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD: "none"
-      PROXY_OIDC_SKIP_VERIFICATION: "false"
-
-      # Enable authelia usernames as username in OpenCloud (instead of an id)
-      # PROXY_USER_OIDC_CLAIM: "preferred_username"
-      # PROXY_AUTOPROVISION_CLAIM_USERNAME: "preferred_username"
-
+      PROXY_OIDC_REWRITE_WELLKNOWN: "true"
+      # Use preferred_username from Authelia as the OpenCloud user identifier
+      PROXY_USER_OIDC_CLAIM: "preferred_username"
+      PROXY_USER_CS3_CLAIM: "username"
+      # Include groups claim for role assignment
+      WEB_OIDC_SCOPE: "openid profile email groups offline_access"
       PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM: "groups"
-      WEB_OIDC_SCOPE: "openid profile email groups"
+      # No auto-provisioning: user management is handled by the external identity provider
+      PROXY_AUTOPROVISION_ACCOUNTS: "false"
+      OC_ADMIN_USER_ID: ""
+      SETTINGS_SETUP_DEFAULT_ASSIGNMENTS: "false"
+      GRAPH_ASSIGN_DEFAULT_USER_ROLE: "true"
+      GRAPH_USERNAME_MATCH: "none"
+      # Allow the external Authelia domain in CSP frame/connect directives
+      IDP_DOMAIN: ${IDP_DOMAIN:?IDP_DOMAIN must be set to your Authelia domain, e.g. auth.example.com}
 
-      # The desktop client currently doesn't work when oidc assignment driver is used : https://github.com/opencloud-eu/desktop/issues/217
-      # That's why you only can use it to bootstrap your admin user currently (if you want to use the desktop client).
+      # Some clients currently doesn't work when oidc assignment driver is used:
+      # https://github.com/opencloud-eu/desktop/issues/217
+      # That's why you can only use it to bootstrap your admin user currently.
       #
       # 1. *Before* first startup: Switch to `PROXY_ROLE_ASSIGNMENT_DRIVER: "oidc"`
       # 2. Start opencloud container to generate initial config: `docker compose up -d`
-      # 3. Map the `opencloud-admin` group from authelia to the `admin` role from OpenCloud in opencloud-config/opencloud.yaml :
-      #
-      # proxy:
-      #   role_assignment:
-      #    oidc_role_mapper:
-      #        role_claim: groups
-      #        role_mapping:
-      #          - role_name: admin
-      #            claim_value: opencloud-admin
+      # 3. Uncomment and adjust the role mapping block in config/opencloud/proxy.yaml:
+      #    Set `claim_value` to the group name in your IdP that should get the `admin` role.
       #
       # 4. Restart opencloud container: `docker compose restart opencloud`
       # 5. Login with your admin user (the one with the `opencloud-admin` group)
-      # 6. Switch back to `PROXY_ROLE_ASSIGNMENT_DRIVER: "default"``
+      # 6. Switch back to `PROXY_ROLE_ASSIGNMENT_DRIVER: "default"`
       # 7. Recreate opencloud container: `docker compose up -d opencloud`
       PROXY_ROLE_ASSIGNMENT_DRIVER: "default"
-      GRAPH_ASSIGN_DEFAULT_USER_ROLE: "true"
+
+      # Optional: if your Authelia instance also manages an LDAP/LLDAP directory,
+      # configure OpenCloud to read user data from it directly:
+      # OC_LDAP_URI: ldap://your-ldap-server:389
+      # OC_LDAP_INSECURE: "true"
+      # OC_LDAP_BIND_DN: "uid=admin,ou=people,dc=example,dc=com"
+      # OC_LDAP_BIND_PASSWORD: ${LDAP_BIND_PASSWORD}
+      # OC_LDAP_GROUP_BASE_DN: "ou=groups,dc=example,dc=com"
+      # OC_LDAP_USER_BASE_DN: "ou=people,dc=example,dc=com"
+      # OC_LDAP_USER_FILTER: "(objectclass=inetOrgPerson)"
+      # OC_LDAP_SERVER_WRITE_ENABLED: "false"
+      # FRONTEND_READONLY_USER_ATTRIBUTES: "user.onPremisesSamAccountName,user.displayName,user.mail,user.passwordProfile,user.accountEnabled,user.appRoleAssignments"

--- a/traefik/authelia-lldap.yml
+++ b/traefik/authelia-lldap.yml
@@ -1,0 +1,26 @@
+---
+services:
+  traefik:
+    networks:
+      opencloud-net:
+        aliases:
+          - ${AUTHELIA_DOMAIN:-auth.opencloud.test}
+          - ${LLDAP_DOMAIN:-lldap.opencloud.test}
+  authelia:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.authelia.entrypoints=https"
+      - "traefik.http.routers.authelia.rule=Host(`${AUTHELIA_DOMAIN:-auth.opencloud.test}`)"
+      - "traefik.http.routers.authelia.${TRAEFIK_SERVICES_TLS_CONFIG}"
+      - "traefik.http.routers.authelia.service=authelia"
+      - "traefik.http.routers.authelia.middlewares=hsts-header"
+      - "traefik.http.services.authelia.loadbalancer.server.port=9091"
+  lldap:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.lldap.entrypoints=https"
+      - "traefik.http.routers.lldap.rule=Host(`${LLDAP_DOMAIN:-lldap.opencloud.test}`)"
+      - "traefik.http.routers.lldap.${TRAEFIK_SERVICES_TLS_CONFIG}"
+      - "traefik.http.routers.lldap.service=lldap"
+      - "traefik.http.routers.lldap.middlewares=hsts-header"
+      - "traefik.http.services.lldap.loadbalancer.server.port=17170"


### PR DESCRIPTION
To address the lot of confusion around how to install and configure Authelia as an authentication backed for Opencloud, like https://github.com/opencloud-eu/desktop/issues/217
I tried to port my solution to match the project structure here. 

`PROXY_ROLE_ASSIGNMENT_DRIVER` works questionably right now, so I included my workflow of bootstrapping the service with `oidc` then use `default` to make all clients work. 



**Disclaimer**:  Docs/comments are AI-aided. Also I don't speak Traefik so that is an AI translation of my Nginx setup. 