### PR TITLE
fix indent in cert example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,8 @@ TRAEFIK_SERVICES_TLS_CONFIG="tls.certresolver=letsencrypt"
 #   certificates:
 #     - certFile: /certs/opencloud.test.crt
 #       keyFile: /certs/opencloud.test.key
-#   stores:
-#     - default
+#       stores:
+#         - default
 #
 # The certificates need to be copied into ./certs/, the absolute path inside the container is /certs/.
 # You can also use TRAEFIK_CERTS_DIR=/path/on/host to set the path to the certificates directory.


### PR DESCRIPTION
The indent in the example is wrong
The README has the correct example: https://github.com/opencloud-eu/opencloud-compose#use-certificates-from-the-certs-directory

So fix it also here