### PR TITLE
Add IDP_DOMAIN to the frame-src section in csp.yaml

### DIFF
--- a/config/opencloud/csp.yaml
+++ b/config/opencloud/csp.yaml
@@ -24,6 +24,7 @@ directives:
     - 'https://${COLLABORA_DOMAIN|collabora.opencloud.test}${TRAEFIK_PORT_HTTPS}/'
     # This is needed for the external-sites web extension when embedding sites
     - 'https://docs.opencloud.eu'
+    - 'https://${IDP_DOMAIN|keycloak.opencloud.test}${TRAEFIK_PORT_HTTPS}/'
   img-src:
     - '''self'''
     - 'data:'


### PR DESCRIPTION
When using an external IDP, not having the IDP FQDN in frame-src causes silent refreshes to get blocked. This addition solved that issue.