### PR TITLE
feat: add compose overlay for external OnlyOffice integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,7 +83,7 @@ TRAEFIK_LOG_LEVEL=
 # For production releases: "opencloudeu/opencloud"
 # For rolling releases:    "opencloudeu/opencloud-rolling"
 # Defaults to production if not set otherwise
-OC_DOCKER_IMAGE=opencloudeu/opencloud-rolling
+OC_DOCKER_IMAGE=opencloudeu/opencloud
 # The openCloud container version.
 # Defaults to "latest" and points to the latest stable tag.
 OC_DOCKER_TAG=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   opencloud:
     # renovate: depName=opencloudeu/opencloud
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.3}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.4}
     # changelog: https://github.com/opencloud-eu/opencloud/tree/main/changelog
     # release notes: https://docs.opencloud.eu/opencloud_release_notes.html
     user: ${OC_CONTAINER_UID_GID:-1000:1000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 ---
 services:
   opencloud:
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-latest}
+    # renovate: depName=opencloudeu/opencloud
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.3}
     # changelog: https://github.com/opencloud-eu/opencloud/tree/main/changelog
     # release notes: https://docs.opencloud.eu/opencloud_release_notes.html
     user: ${OC_CONTAINER_UID_GID:-1000:1000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   opencloud:
     # renovate: depName=opencloudeu/opencloud
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.4}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.5}
     # changelog: https://github.com/opencloud-eu/opencloud/tree/main/changelog
     # release notes: https://docs.opencloud.eu/opencloud_release_notes.html
     user: ${OC_CONTAINER_UID_GID:-1000:1000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   opencloud:
     # renovate: depName=opencloudeu/opencloud
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.5}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.7}
     # changelog: https://github.com/opencloud-eu/opencloud/tree/main/changelog
     # release notes: https://docs.opencloud.eu/opencloud_release_notes.html
     user: ${OC_CONTAINER_UID_GID:-1000:1000}

--- a/idm/ldap-keycloak.yml
+++ b/idm/ldap-keycloak.yml
@@ -64,7 +64,7 @@ services:
     restart: always
 
   postgres:
-    image: postgres:17-alpine
+    image: postgres:17.7-alpine
     networks:
       opencloud-net:
     volumes:

--- a/search/tika.yml
+++ b/search/tika.yml
@@ -1,7 +1,7 @@
 ---
 services:
   tika:
-    image: ${TIKA_IMAGE:-apache/tika:latest}
+    image: ${TIKA_IMAGE:-apache/tika:3.2.3.0}
     # Using the base variant for smaller image size and faster startup
     # The base variant includes core functionality for text extraction
     # Full variant is only needed for specialized OCR/image processing

--- a/testing/external-keycloak.yml
+++ b/testing/external-keycloak.yml
@@ -1,7 +1,7 @@
 ---
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:17.7-alpine
     networks:
       opencloud-net:
     volumes:

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -9,7 +9,7 @@ services:
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
       - "traefik.http.routers.opencloud.${TRAEFIK_SERVICES_TLS_CONFIG}"
   traefik:
-    image: traefik:v3
+    image: traefik:v3.6.2
     # release notes: https://github.com/traefik/traefik/releases
     user: ${TRAEFIK_CONTAINER_UID_GID:-0:0}
     networks:

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -9,7 +9,7 @@ services:
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
       - "traefik.http.routers.opencloud.${TRAEFIK_SERVICES_TLS_CONFIG}"
   traefik:
-    image: traefik:v3.6.11
+    image: traefik:v3.6.12
     # release notes: https://github.com/traefik/traefik/releases
     user: ${TRAEFIK_CONTAINER_UID_GID:-0:0}
     networks:

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -9,7 +9,7 @@ services:
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
       - "traefik.http.routers.opencloud.${TRAEFIK_SERVICES_TLS_CONFIG}"
   traefik:
-    image: traefik:v3.6.9
+    image: traefik:v3.6.10
     # release notes: https://github.com/traefik/traefik/releases
     user: ${TRAEFIK_CONTAINER_UID_GID:-0:0}
     networks:

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -9,7 +9,7 @@ services:
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
       - "traefik.http.routers.opencloud.${TRAEFIK_SERVICES_TLS_CONFIG}"
   traefik:
-    image: traefik:v3.6.2
+    image: traefik:v3.6.9
     # release notes: https://github.com/traefik/traefik/releases
     user: ${TRAEFIK_CONTAINER_UID_GID:-0:0}
     networks:

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -9,7 +9,7 @@ services:
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
       - "traefik.http.routers.opencloud.${TRAEFIK_SERVICES_TLS_CONFIG}"
   traefik:
-    image: traefik:v3.6.10
+    image: traefik:v3.6.11
     # release notes: https://github.com/traefik/traefik/releases
     user: ${TRAEFIK_CONTAINER_UID_GID:-0:0}
     networks:

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -9,7 +9,7 @@ services:
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
       - "traefik.http.routers.opencloud.${TRAEFIK_SERVICES_TLS_CONFIG}"
   traefik:
-    image: traefik:v3.6.12
+    image: traefik:v3.6.13
     # release notes: https://github.com/traefik/traefik/releases
     user: ${TRAEFIK_CONTAINER_UID_GID:-0:0}
     networks:

--- a/traefik/opencloud.yml
+++ b/traefik/opencloud.yml
@@ -9,7 +9,7 @@ services:
       - "traefik.http.services.opencloud.loadbalancer.server.port=9200"
       - "traefik.http.routers.opencloud.${TRAEFIK_SERVICES_TLS_CONFIG}"
   traefik:
-    image: traefik:v3.6.13
+    image: traefik:v3.6.14
     # release notes: https://github.com/traefik/traefik/releases
     user: ${TRAEFIK_CONTAINER_UID_GID:-0:0}
     networks:

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -15,7 +15,7 @@ services:
 
   collaboration:
     # renovate: depName=opencloudeu/opencloud
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.4}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.5}
     user: ${OC_CONTAINER_UID_GID:-1000:1000}
     networks:
       opencloud-net:

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -48,7 +48,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:25.04.7.1.1
+    image: collabora/code:25.04.9.2.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       opencloud-net:

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -49,7 +49,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:25.04.9.3.1
+    image: collabora/code:25.04.9.4.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       opencloud-net:

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -49,7 +49,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:25.04.9.2.1
+    image: collabora/code:25.04.9.3.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       opencloud-net:

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -14,7 +14,8 @@ services:
       GRAPH_AVAILABLE_ROLES: "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5,a8d5fe5e-96e3-418d-825b-534dbdf22b99,fb6c3e19-e378-47e5-b277-9732f9de6e21,58c63c02-1d89-4572-916a-870abc5a1b7d,2d00ce52-1fc2-4dbc-8b95-a73b73395f5a,1c996275-f1c9-4e71-abdf-a42f6495e960,312c0871-5ef7-4b3a-85b6-0e4074c64049,aa97fe03-7980-45ac-9e50-b325749fd7e6"
 
   collaboration:
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-latest}
+    # renovate: depName=opencloudeu/opencloud
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.3}
     user: ${OC_CONTAINER_UID_GID:-1000:1000}
     networks:
       opencloud-net:

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -15,7 +15,7 @@ services:
 
   collaboration:
     # renovate: depName=opencloudeu/opencloud
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.3}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.4}
     user: ${OC_CONTAINER_UID_GID:-1000:1000}
     networks:
       opencloud-net:

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -49,7 +49,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:25.04.9.4.1
+    image: collabora/code:25.04.10.3.1
     # release notes: https://www.collaboraonline.com/release-notes/
     networks:
       opencloud-net:

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -15,7 +15,7 @@ services:
 
   collaboration:
     # renovate: depName=opencloudeu/opencloud
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.5}
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-4.0.7}
     user: ${OC_CONTAINER_UID_GID:-1000:1000}
     networks:
       opencloud-net:

--- a/weboffice/onlyoffice.yml
+++ b/weboffice/onlyoffice.yml
@@ -1,0 +1,41 @@
+---
+services:
+  opencloud:
+    environment:
+      NATS_NATS_HOST: 0.0.0.0
+      GATEWAY_GRPC_ADDR: 0.0.0.0:9142
+      FRONTEND_APP_HANDLER_SECURE_VIEW_APP_ADDR: eu.opencloud.api.collaboration
+      GRAPH_AVAILABLE_ROLES: "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5,a8d5fe5e-96e3-418d-825b-534dbdf22b99,fb6c3e19-e378-47e5-b277-9732f9de6e21,58c63c02-1d89-4572-916a-870abc5a1b7d,2d00ce52-1fc2-4dbc-8b95-a73b73395f5a,1c996275-f1c9-4e71-abdf-a42f6495e960,312c0871-5ef7-4b3a-85b6-0e4074c64049,aa97fe03-7980-45ac-9e50-b325749fd7e6"
+
+  collaboration:
+    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-latest}
+    user: ${OC_CONTAINER_UID_GID:-1000:1000}
+    networks:
+      opencloud-net:
+    depends_on:
+      opencloud:
+        condition: service_started
+    entrypoint:
+      - /bin/sh
+    command: ["-c", "opencloud collaboration server"]
+    environment:
+      COLLABORATION_GRPC_ADDR: 0.0.0.0:9301
+      COLLABORATION_HTTP_ADDR: 0.0.0.0:9300
+      MICRO_REGISTRY: "nats-js-kv"
+      MICRO_REGISTRY_ADDRESS: "opencloud:9233"
+      OC_URL: ${OC_URL}
+      COLLABORATION_WOPI_SRC: ${WOPISERVER_URL:-http://collaboration:9300}
+      COLLABORATION_WOPI_SECRET: ${ONLYOFFICE_JWT_SECRET}
+      COLLABORATION_APP_NAME: "OnlyOffice"
+      COLLABORATION_APP_PRODUCT: "OnlyOffice"
+      COLLABORATION_APP_ADDR: ${ONLYOFFICE_URL:-https://onlyoffice.opencloud.test}
+      COLLABORATION_APP_ICON: ${ONLYOFFICE_URL:-https://onlyoffice.opencloud.test}/web-apps/apps/documenteditor/main/resources/img/favicon.ico
+      COLLABORATION_APP_INSECURE: "${INSECURE:-false}"
+      COLLABORATION_CS3API_DATAGATEWAY_INSECURE: "${INSECURE:-false}"
+      COLLABORATION_APP_PROOF_DISABLE: "true"
+      COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
+    volumes:
+      - ${OC_CONFIG_DIR:-opencloud-config}:/etc/opencloud
+    logging:
+      driver: ${LOG_DRIVER:-local}
+    restart: always


### PR DESCRIPTION
Currently, the `opencloud-compose` repository provides an overlay for the embedded Collabora instance (`weboffice/collabora.yml`), but lacks an out-of-the-box overlay for integrating an external OnlyOffice Document Server.

This PR adds `weboffice/onlyoffice.yml`, which runs the `collaboration` WOPI microservice pre-configured for OnlyOffice.

**Key features of this overlay:**
- Sets `COLLABORATION_APP_PRODUCT: "OnlyOffice"`
- Exposes `ONLYOFFICE_URL`, `WOPISERVER_URL`, and `ONLYOFFICE_JWT_SECRET` for easy configuration via `.env`.
- Disables Proof Keys (`COLLABORATION_APP_PROOF_DISABLE: "true"`) since OnlyOffice 7.2+ relies strictly on JWT validation.

Tested and working in production. This should save future administrators hours of reverse-engineering the acceptance tests.