### PR TITLE
set OC_EVENTS_ENDPOINT for collaboration

### DIFF
--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -41,6 +41,7 @@ services:
       COLLABORATION_CS3API_DATAGATEWAY_INSECURE: "${INSECURE:-true}"
       COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
       OC_URL: https://${OC_DOMAIN:-cloud.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
+      OC_EVENTS_ENDPOINT: "opencloud:9233"
     volumes:
       # configure the .env file to use own paths instead of docker internal volumes
       - ${OC_CONFIG_DIR:-opencloud-config}:/etc/opencloud


### PR DESCRIPTION
related https://github.com/opencloud-eu/opencloud/pull/2862

Steps: 
- start `COMPOSE_FILE=docker-compose.yml:weboffice/collabora.yml:traefik/opencloud.yml:traefik/collabora.yml`

### Result before: user cannot open file in collabora
```
{"level":"error","error":"error connecting to nats cluster opencloud-cluster: error connecting to nats at 127.0.0.1:9233 with tls enabled (false): nats: no servers available for connection","time":"2026-06-16T09:45:50Z","caller":"/woodpecker/src/github.com/opencloud-eu/web/repo_opencloud/vendor/github.com/cenkalti/backoff/retry.go:24","message":"can't connect to nats (jetstream) server, retrying in 6.263457302s"}

```

### result now: works fine
