### PR TITLE
fix: collabora healthcheck without curl

### DIFF
--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -83,7 +83,13 @@ services:
     entrypoint: [ '/bin/bash', '-c' ]
     command: [ 'coolconfig generate-proof-key && /start-collabora-online.sh' ]
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:9980/hosting/discovery" ]
+      test:
+        [
+          "CMD",
+          "bash",
+          "-c",
+          "exec 3<>/dev/tcp/127.0.0.1/9980 && printf 'GET /hosting/discovery HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 && cat <&3 | head -1 | grep -q '200 OK'"
+        ]
       interval: 15s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
There is no more `curl` binary in the new collabora image.

This changes the healthcheck. It now opens a raw TCP connection to port 9980 via bash's /dev/tcp, sends an HTTP request to /hosting/discovery, and checks for a 200 OK response.