### PR TITLE
feat: move collaboration into the opencloud process

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -219,9 +219,9 @@ TIKA_IMAGE=
 # Domain of Collabora, where you can find the frontend.
 # Defaults to "collabora.opencloud.test"
 COLLABORA_DOMAIN=
-# Domain of the wopiserver which handles Collabora.
-# Defaults to "wopiserver.opencloud.test"
-WOPISERVER_DOMAIN=
+# NOTE: The WOPI server runs inside the main OpenCloud process and is served by
+# the OpenCloud proxy on the main OpenCloud domain (OC_DOMAIN) under the /wopi and
+# /collaboration paths. It no longer needs its own domain.
 # Admin user for Collabora.
 # Defaults to "admin".
 # Collabora Admin Panel URL:

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ This setup includes:
 ### With Collabora Online
 
 > [!NOTE]
-> Collabora Online and [Euro Office](#with-euro-office) are mutually exclusive web office backends — both use the same `collaboration` (WOPI) service. Enable only one of them at a time.
+> Collabora Online and [Euro Office](#with-euro-office) are mutually exclusive web office backends — both use the same `collaboration` (WOPI) service, which runs inside the main OpenCloud process. Enable only one of them at a time.
 
 Include Collabora for document editing using either method:
 
-> **DNS Requirements**: This setup requires DNS entries for the main OpenCloud domain, Collabora subdomain, and WOPI server subdomain. Configure DNS A/AAAA records for your domains (e.g., `cloud.example.com`, `collabora.example.com`, `wopiserver.example.com`) or use a wildcard DNS entry (`*.example.com`).
+> **DNS Requirements**: This setup requires DNS entries for the main OpenCloud domain and the Collabora subdomain. The WOPI server is served by OpenCloud on the main domain, so it does not need its own subdomain. Configure DNS A/AAAA records for your domains (e.g., `cloud.example.com`, `collabora.example.com`) or use a wildcard DNS entry (`*.example.com`).
 
 Using `-f` flags:
 ```bash
@@ -128,17 +128,22 @@ COMPOSE_FILE=docker-compose.yml:weboffice/collabora.yml:traefik/opencloud.yml:tr
 > **For local development only**: Add to `/etc/hosts`:
 > ```
 > 127.0.0.1 collabora.opencloud.test
-> 127.0.0.1 wopiserver.opencloud.test
 > ```
+
+> [!IMPORTANT]
+> **Upgrading from a previous setup**: The `collaboration` (WOPI) service no longer runs as a separate container or on its own `wopiserver.*` domain — it now runs inside the main OpenCloud process and is served by the OpenCloud proxy on the main domain under the `/wopi` and `/collaboration` paths. When upgrading:
+> - Pull the latest compose files and recreate the stack (`docker compose up -d`). The old `collaboration` container is removed automatically.
+> - You can retire the `wopiserver.*` DNS entry (and its `/etc/hosts` line), its reverse-proxy/Traefik route, and the `WOPISERVER_DOMAIN` variable in `.env` — all are now unused.
+> - If you run behind an external proxy, make sure it forwards `/wopi` and `/collaboration` on the OpenCloud domain to OpenCloud (port 9200). Forwarding the whole OpenCloud domain, as already configured, covers this.
 
 ### With Euro Office
 
 > [!NOTE]
-> Euro Office and [Collabora Online](#with-collabora-online) are mutually exclusive web office backends — both use the same `collaboration` (WOPI) service. Enable only one of them at a time.
+> Euro Office and [Collabora Online](#with-collabora-online) are mutually exclusive web office backends — both use the same `collaboration` (WOPI) service, which runs inside the main OpenCloud process. Enable only one of them at a time.
 
 Include Euro Office for document editing using either method:
 
-> **DNS Requirements**: This setup requires DNS entries for the main OpenCloud domain, Euro Office subdomain, and WOPI server subdomain. Configure DNS A/AAAA records for your domains (e.g., `cloud.example.com`, `euro-office.example.com`, `wopiserver.example.com`) or use a wildcard DNS entry (`*.example.com`).
+> **DNS Requirements**: This setup requires DNS entries for the main OpenCloud domain and the Euro Office subdomain. The WOPI server is served by OpenCloud on the main domain, so it does not need its own subdomain. Configure DNS A/AAAA records for your domains (e.g., `cloud.example.com`, `euro-office.example.com`) or use a wildcard DNS entry (`*.example.com`).
 
 Using `-f` flags:
 ```bash
@@ -153,11 +158,13 @@ COMPOSE_FILE=docker-compose.yml:weboffice/euroffice.yml:traefik/opencloud.yml:tr
 > **For local development only**: Add to `/etc/hosts`:
 > ```
 > 127.0.0.1 euro-office.opencloud.test
-> 127.0.0.1 wopiserver.opencloud.test
 > ```
 
 > [!IMPORTANT]
 > Set a strong `EURO_OFFICE_JWT_SECRET` in your `.env` file for production. The default value (`changeme`) is intended for local development only.
+
+> [!NOTE]
+> Upgrading from a previous setup? See [Upgrading from a previous setup](#with-collabora-online) under Collabora Online — the WOPI server changes (no more separate container or `wopiserver.*` domain) apply to Euro Office as well.
 
 ### With Full Text Search
 
@@ -258,7 +265,8 @@ COMPOSE_FILE=docker-compose.yml:weboffice/collabora.yml:external-proxy/opencloud
 This exposes the necessary ports:
 - OpenCloud: 9200
 - Collabora: 9980
-- WOPI server: 9300
+
+The WOPI server runs inside the OpenCloud process and is served on the OpenCloud port (9200) under the `/wopi` and `/collaboration` paths, so no separate port needs to be exposed for it.
 
 To use Euro Office instead of Collabora behind an external proxy, swap the web office compose files:
 
@@ -274,7 +282,8 @@ COMPOSE_FILE=docker-compose.yml:weboffice/euroffice.yml:external-proxy/opencloud
 This exposes the necessary ports:
 - OpenCloud: 9200
 - Euro Office: 9900
-- WOPI server: 9300
+
+As with Collabora, the WOPI server is served on the OpenCloud port (9200) under the `/wopi` and `/collaboration` paths and needs no separate port.
 
 > [!WARNING]
 > `external-proxy/euroffice.yml` binds the exposed ports to `127.0.0.1` only. If your external proxy runs on a different host, use `external-proxy/euroffice-exposed.yml`, which binds to all interfaces (`0.0.0.0`). Only expose these ports when you know what you are doing.
@@ -392,7 +401,6 @@ Key variables:
 | `OC_DATA_DIR`                 | Data directory path                                   | (Docker volume)              |
 | `INSECURE`                    | Skip certificate validation                           | true                         |
 | `COLLABORA_DOMAIN`            | Collabora domain                                      | collabora.opencloud.test     |
-| `WOPISERVER_DOMAIN`           | WOPI server domain                                    | wopiserver.opencloud.test    |
 | `EURO_OFFICE_DOMAIN`          | Euro Office document server domain                    | euro-office.opencloud.test   |
 | `EURO_OFFICE_JWT_SECRET`      | JWT secret for Euro Office (change for production!)   | changeme                     |
 | `EURO_OFFICE_DOCKER_IMAGE`    | Euro Office Docker image                              | ghcr.io/euro-office/documentserver |

--- a/external-proxy/collabora-exposed.yml
+++ b/external-proxy/collabora-exposed.yml
@@ -1,10 +1,6 @@
 ---
 # only expose the ports when you know what you are doing!
 services:
-  collaboration:
-    ports:
-      # expose the wopi server on all interfaces
-      - "0.0.0.0:9300:9300"
   collabora:
     ports:
       # expose the collabora server on all interfaces

--- a/external-proxy/collabora.yml
+++ b/external-proxy/collabora.yml
@@ -1,9 +1,5 @@
 ---
 services:
-  collaboration:
-    ports:
-      # expose the wopi server on localhost
-      - "127.0.0.1:9300:9300"
   collabora:
     ports:
       # expose the collabora server on localhost

--- a/external-proxy/euroffice-exposed.yml
+++ b/external-proxy/euroffice-exposed.yml
@@ -1,10 +1,6 @@
 ---
 # only expose the ports when you know what you are doing!
 services:
-  collaboration:
-    ports:
-      # expose the wopi server on all interfaces
-      - "0.0.0.0:9300:9300"
   euro-office:
     ports:
       # expose the euro-office document server on all interfaces

--- a/external-proxy/euroffice.yml
+++ b/external-proxy/euroffice.yml
@@ -1,9 +1,5 @@
 ---
 services:
-  collaboration:
-    ports:
-      # expose the wopi server on localhost
-      - "127.0.0.1:9300:9300"
   euro-office:
     ports:
       # expose the euro-office document server on localhost

--- a/traefik/collabora.yml
+++ b/traefik/collabora.yml
@@ -5,16 +5,6 @@ services:
       opencloud-net:
         aliases:
           - ${COLLABORA_DOMAIN:-collabora.opencloud.test}
-          - ${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}
-  collaboration:
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.collaboration.entrypoints=https"
-      - "traefik.http.routers.collaboration.rule=Host(`${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}`)"
-      - "traefik.http.routers.collaboration.${TRAEFIK_SERVICES_TLS_CONFIG}"
-      - "traefik.http.routers.collaboration.service=collaboration"
-      - "traefik.http.routers.collaboration.middlewares=hsts-header"
-      - "traefik.http.services.collaboration.loadbalancer.server.port=9300"
   collabora:
     labels:
       - "traefik.enable=true"

--- a/traefik/euroffice.yml
+++ b/traefik/euroffice.yml
@@ -5,16 +5,6 @@ services:
       opencloud-net:
         aliases:
           - ${EURO_OFFICE_DOMAIN:-euro-office.opencloud.test}
-          - ${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}
-  collaboration:
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.collaboration.entrypoints=https"
-      - "traefik.http.routers.collaboration.rule=Host(`${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}`)"
-      - "traefik.http.routers.collaboration.${TRAEFIK_SERVICES_TLS_CONFIG}"
-      - "traefik.http.routers.collaboration.service=collaboration"
-      - "traefik.http.routers.collaboration.middlewares=hsts-header"
-      - "traefik.http.services.collaboration.loadbalancer.server.port=9300"
   euro-office:
     labels:
       - "traefik.enable=true"

--- a/weboffice/collabora.yml
+++ b/weboffice/collabora.yml
@@ -6,48 +6,22 @@ services:
       # this is needed for setting the correct CSP header
       COLLABORA_DOMAIN: ${COLLABORA_DOMAIN:-collabora.opencloud.test}
       TRAEFIK_PORT_HTTPS: ${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
-      # expose nats and the reva gateway for the collaboration service
-      NATS_NATS_HOST: 0.0.0.0
-      GATEWAY_GRPC_ADDR: 0.0.0.0:9142
+      # run the collaboration (WOPI) service inside the main opencloud process,
+      # appended to any user defined services in START_ADDITIONAL_SERVICES
+      OC_ADD_RUN_SERVICES: ${START_ADDITIONAL_SERVICES:-}${START_ADDITIONAL_SERVICES:+,}collaboration
       # make collabora the secure view app
       FRONTEND_APP_HANDLER_SECURE_VIEW_APP_ADDR: eu.opencloud.api.collaboration
       GRAPH_AVAILABLE_ROLES: "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5,a8d5fe5e-96e3-418d-825b-534dbdf22b99,fb6c3e19-e378-47e5-b277-9732f9de6e21,58c63c02-1d89-4572-916a-870abc5a1b7d,2d00ce52-1fc2-4dbc-8b95-a73b73395f5a,1c996275-f1c9-4e71-abdf-a42f6495e960,312c0871-5ef7-4b3a-85b6-0e4074c64049,aa97fe03-7980-45ac-9e50-b325749fd7e6"
-
-  collaboration:
-    # renovate: depName=opencloudeu/opencloud-rolling
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-6.2.0}
-    user: ${OC_CONTAINER_UID_GID:-1000:1000}
-    networks:
-      opencloud-net:
-    depends_on:
-      opencloud:
-        condition: service_started
-      collabora:
-        condition: service_healthy
-    entrypoint:
-      - /bin/sh
-    command: [ "-c", "opencloud collaboration server" ]
-    environment:
-      COLLABORATION_GRPC_ADDR: 0.0.0.0:9301
-      COLLABORATION_HTTP_ADDR: 0.0.0.0:9300
-      MICRO_REGISTRY: "nats-js-kv"
-      MICRO_REGISTRY_ADDRESS: "opencloud:9233"
-      COLLABORATION_WOPI_SRC: https://${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
+      # collaboration service configuration; the WOPI endpoint is served by the
+      # opencloud proxy on the opencloud domain (/wopi and /collaboration routes),
+      # so no separate wopiserver domain, route or port is needed
+      COLLABORATION_WOPI_SRC: https://${OC_DOMAIN:-cloud.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
       COLLABORATION_APP_NAME: "CollaboraOnline"
       COLLABORATION_APP_PRODUCT: "Collabora"
       COLLABORATION_APP_ADDR: https://${COLLABORA_DOMAIN:-collabora.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
       COLLABORATION_APP_ICON: https://${COLLABORA_DOMAIN:-collabora.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}/favicon.ico
       COLLABORATION_APP_INSECURE: "${INSECURE:-true}"
       COLLABORATION_CS3API_DATAGATEWAY_INSECURE: "${INSECURE:-true}"
-      COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
-      OC_URL: https://${OC_DOMAIN:-cloud.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
-      OC_EVENTS_ENDPOINT: "opencloud:9233"
-    volumes:
-      # configure the .env file to use own paths instead of docker internal volumes
-      - ${OC_CONFIG_DIR:-opencloud-config}:/etc/opencloud
-    logging:
-      driver: ${LOG_DRIVER:-local}
-    restart: always
 
   collabora:
     image: collabora/code:26.04.1.4.1
@@ -55,7 +29,8 @@ services:
     networks:
       opencloud-net:
     environment:
-      aliasgroup1: https://${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
+      # WOPI host allowlist; the WOPI endpoint is served by the opencloud proxy on the opencloud domain
+      aliasgroup1: https://${OC_DOMAIN:-cloud.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
       DONT_GEN_SSL_CERT: "YES"
       extra_params: |
         --o:ssl.enable=${COLLABORA_SSL_ENABLE:-true} \

--- a/weboffice/euroffice.yml
+++ b/weboffice/euroffice.yml
@@ -6,32 +6,13 @@ services:
       # this is needed for setting the correct CSP header
       EURO_OFFICE_DOMAIN: ${EURO_OFFICE_DOMAIN:-euro-office.opencloud.test}
       TRAEFIK_PORT_HTTPS: ${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
-      # expose nats and the reva gateway for the collaboration service
-      NATS_NATS_HOST: 0.0.0.0
-      GATEWAY_GRPC_ADDR: 0.0.0.0:9142
-    volumes:
-      - ./config/euro-office/app-registry.yaml:/etc/opencloud/app-registry.yaml
-
-  collaboration:
-    # renovate: depName=opencloudeu/opencloud-rolling
-    image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud-rolling}:${OC_DOCKER_TAG:-6.2.0}
-    user: ${OC_CONTAINER_UID_GID:-1000:1000}
-    networks:
-      opencloud-net:
-    depends_on:
-      opencloud:
-        condition: service_started
-      euro-office:
-        condition: service_healthy
-    entrypoint:
-      - /bin/sh
-    command: [ "-c", "opencloud collaboration server" ]
-    environment:
-      COLLABORATION_GRPC_ADDR: 0.0.0.0:9301
-      COLLABORATION_HTTP_ADDR: 0.0.0.0:9300
-      MICRO_REGISTRY: "nats-js-kv"
-      MICRO_REGISTRY_ADDRESS: "opencloud:9233"
-      COLLABORATION_WOPI_SRC: https://${WOPISERVER_DOMAIN:-wopiserver.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
+      # run the collaboration (WOPI) service inside the main opencloud process,
+      # appended to any user defined services in START_ADDITIONAL_SERVICES
+      OC_ADD_RUN_SERVICES: ${START_ADDITIONAL_SERVICES:-}${START_ADDITIONAL_SERVICES:+,}collaboration
+      # collaboration service configuration; the WOPI endpoint is served by the
+      # opencloud proxy on the opencloud domain (/wopi and /collaboration routes),
+      # so no separate wopiserver domain, route or port is needed
+      COLLABORATION_WOPI_SRC: https://${OC_DOMAIN:-cloud.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
       COLLABORATION_APP_NAME: "Euro-Office"
       COLLABORATION_APP_PRODUCT: "OnlyOffice"
       COLLABORATION_APP_ADDR: https://${EURO_OFFICE_DOMAIN:-euro-office.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
@@ -39,15 +20,8 @@ services:
       COLLABORATION_APP_INSECURE: "${INSECURE:-true}"
       COLLABORATION_CS3API_DATAGATEWAY_INSECURE: "${INSECURE:-true}"
       COLLABORATION_APP_PROOF_DISABLE: "true"
-      COLLABORATION_LOG_LEVEL: ${LOG_LEVEL:-info}
-      OC_URL: https://${OC_DOMAIN:-cloud.opencloud.test}${TRAEFIK_PORT_HTTPS:+:}${TRAEFIK_PORT_HTTPS:-}
-      OC_EVENTS_ENDPOINT: "opencloud:9233"
     volumes:
-      # configure the .env file to use own paths instead of docker internal volumes
-      - ${OC_CONFIG_DIR:-opencloud-config}:/etc/opencloud
-    logging:
-      driver: ${LOG_DRIVER:-local}
-    restart: always
+      - ./config/euro-office/app-registry.yaml:/etc/opencloud/app-registry.yaml
 
   euro-office:
     image: ${EURO_OFFICE_DOCKER_IMAGE:-ghcr.io/euro-office/documentserver}:${EURO_OFFICE_DOCKER_TAG:-latest}


### PR DESCRIPTION
# Description

The WOPI server runs inside the main OpenCloud process and is served by
the OpenCloud proxy on the main OpenCloud domain (OC_DOMAIN) under the /wopi and
/collaboration paths. It no longer needs its own domain.