### PR TITLE
feat: add admin password secret option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,8 @@ DEMO_USERS=
 # After the first initialization, the admin password can only be changed via the OpenCloud User Settings UI or by using the OpenCloud CLI.
 # Documentation: https://docs.opencloud.eu/docs/admin/resources/common-issues#-change-admin-password-set-in-env
 INITIAL_ADMIN_PASSWORD=
+# To read the admin password from ./secrets/idm_admin_password instead, add
+# secrets/idm-admin-password.yml to COMPOSE_FILE and leave INITIAL_ADMIN_PASSWORD empty.
 # Whether clients should check for updates.
 # Defaults to "true".
 CHECK_FOR_UPDATES=

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 # exclude the certificates config folder
 /config/traefik/dynamic/*
 !/config/traefik/dynamic/.gitkeep
+
+# exclude local secrets
+/secrets/idm_admin_password

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Key variables:
 |-------------------------------|-------------------------------------------------------|------------------------------|
 | `COMPOSE_FILE`                | Colon-separated list of compose files to use          | (commented out)              |
 | `OC_DOMAIN`                   | OpenCloud domain                                      | cloud.opencloud.test         |
-| `INITIAL_ADMIN_PASSWORD `     | OpenCloud password for the admin user                 | (no value)                   |
+| `INITIAL_ADMIN_PASSWORD`      | OpenCloud password for the admin user                 | (no value)                   |
 | `OC_DOCKER_TAG`               | OpenCloud image tag                                   | latest                       |
 | `OC_CONFIG_DIR`               | Config directory path                                 | (Docker volume)              |
 | `OC_DATA_DIR`                 | Data directory path                                   | (Docker volume)              |
@@ -427,6 +427,15 @@ For external LDAP servers, the admin password is managed by the LDAP server itse
 ```
 INITIAL_ADMIN_PASSWORD=your-secure-password-here
 ```
+Alternatively, use Docker secrets:
+
+```bash
+mkdir -p secrets
+printf '%s' 'your-secure-password-here' > secrets/idm_admin_password
+COMPOSE_FILE=docker-compose.yml:secrets/idm-admin-password.yml
+```
+
+Leave `INITIAL_ADMIN_PASSWORD` empty when using `IDM_ADMIN_PASSWORD_FILE`.
 
 For more details, see the [OpenCloud documentation](https://docs.opencloud.eu/docs/admin/resources/common-issues#-change-admin-password-set-in-env).
 

--- a/secrets/idm-admin-password.yml
+++ b/secrets/idm-admin-password.yml
@@ -1,0 +1,11 @@
+---
+services:
+  opencloud:
+    environment:
+      IDM_ADMIN_PASSWORD_FILE: /run/secrets/idm_admin_password
+    secrets:
+      - idm_admin_password
+
+secrets:
+  idm_admin_password:
+    file: ./secrets/idm_admin_password


### PR DESCRIPTION
Draft PR for adding Docker secret support for the initial OpenCloud admin password in the compose setup.

   This adds:

   - `secrets/idm-admin-password.yml` compose override
   - `.env.example` hint for using the secret override
   - README docs for `IDM_ADMIN_PASSWORD_FILE`

   This depends on server support from:

   - https://github.com/opencloud-eu/opencloud/pull/3034

   ## Related Issue

   - Fixes https://github.com/opencloud-eu/opencloud-compose/issues/306

   ## Motivation and Context

   Allows deployments to provide the IDM admin password via Docker secrets / mounted files instead of setting
 `INITIAL_ADMIN_PASSWORD` directly in `.env`.

   This PR should stay as draft until the related server PR is accepted, because `IDM_ADMIN_PASSWORD_FILE` needs server-side
 support first.

   ## How Has This Been Tested?

   - test environment: local checkout on branch `feat/306_idm_admin_password_file`
   - test case 1: default compose config still renders

   ```sh
   docker compose config
 ```

 - test case 2: secret override compose config renders

 ```sh
   printf '%s' secret > secrets/idm_admin_password
   COMPOSE_FILE=docker-compose.yml:secrets/idm-admin-password.yml docker compose config
   rm -f secrets/idm_admin_password
 ```

 Screenshots (if appropriate):

 N/A

 Types of changes

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Technical debt
 - [ ] Tests only (no source changes)

 Checklist:

 - [ ] Code changes
 - [ ] Unit tests added
 - [ ] Acceptance tests added
 - [x] Documentation added
 ```