### PR TITLE
Add Renovate comment for opencloud dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 ---
 services:
   opencloud:
+    # renovate: depName=opencloudeu/opencloud
     image: ${OC_DOCKER_IMAGE:-opencloudeu/opencloud}:${OC_DOCKER_TAG:-7.2.0}
     # changelog: https://github.com/opencloud-eu/opencloud/tree/main/changelog
     # release notes: https://docs.opencloud.eu/opencloud_release_notes.html


### PR DESCRIPTION
after merging https://github.com/opencloud-eu/opencloud-compose/pull/334 renovate didn't create PR for opencloud update. I believe that reason is missing comment 