### PR TITLE
feat: add apps.yaml config

### DIFF
--- a/config/opencloud/apps.yaml
+++ b/config/opencloud/apps.yaml
@@ -1,0 +1,3 @@
+maps:
+  config:
+    folderViewEnabled: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       OC_DEFAULT_LANGUAGE: ${DEFAULT_LANGUAGE}
     volumes:
       - ./config/opencloud/csp.yaml:/etc/opencloud/csp.yaml
+      - ./config/opencloud/apps.yaml:/etc/opencloud/apps.yaml
       - ./config/opencloud/banned-password-list.txt:/etc/opencloud/banned-password-list.txt
       # configure the .env file to use own paths instead of docker internal volumes
       - ${OC_CONFIG_DIR:-opencloud-config}:/etc/opencloud


### PR DESCRIPTION
Add a config for the maps map. Its purpose is not to change anything but to guide and show users how to configure web apps. Now that the `apps.yaml` file is mounted, it can easily be extended by more config options.