### PR TITLE
chore: enable Renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
   "platformAutomerge": true,
   "enabledManagers": ["docker-compose", "custom.regex"],
   "baseBranchPatterns": ["main", "stable-4.0", "stable-7.2"],


### PR DESCRIPTION
after creating new 7.2.4 tag - renovate didn't create PR for update. I was waiting 2 hours but nothing

I enabled renovate dependency dashboard to get the dashboard issue. example: https://github.com/opencloud-eu/n8n-nodes-opencloud/issues/3
o be able to run the updade (trigger renovate)

<img width="698" height="60" alt="image" src="https://github.com/user-attachments/assets/a82f4ead-6451-49ab-b795-a8606db40043" />
